### PR TITLE
Menu Icons styled, margin and spacing

### DIFF
--- a/obfx_modules/menu-icons/css/public.css
+++ b/obfx_modules/menu-icons/css/public.css
@@ -1,0 +1,7 @@
+.obfx-menu-icon.fa,
+.obfx-menu-icon.dashicons,
+.obfx-menu-icon {
+    margin-top: -3px;
+    margin-right: 3px;
+    vertical-align: middle;
+}

--- a/obfx_modules/menu-icons/init.php
+++ b/obfx_modules/menu-icons/init.php
@@ -120,6 +120,7 @@ class Menu_Icons_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		return array(
 			'css' => array(
 				'https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css' => array( 'dashicons' ),
+				'public' => false,
 			),
 		);
 	}


### PR DESCRIPTION
vertical-align and margin-right on icons
The issue was when using dashicons in the very top bar menu in Hestia