### PR TITLE
fix: Menu icons vertical alignment

### DIFF
--- a/obfx_modules/menu-icons/css/public.css
+++ b/obfx_modules/menu-icons/css/public.css
@@ -5,3 +5,9 @@
     margin-right: 3px;
     vertical-align: middle;
 }
+
+#nv-primary-navigation .obfx-menu-icon.dashicons,
+#nv-primary-navigation .obfx-menu-icon.dashicons::before {
+    display: inline-flex;
+    align-self: center;
+}


### PR DESCRIPTION
Vertically align dashicons in Neve primary menu.

https://github.com/Codeinwp/themeisle-companion/issues/314