### PR TITLE
Fix beaver widgets module

### DIFF
--- a/obfx_modules/beaver-widgets/init.php
+++ b/obfx_modules/beaver-widgets/init.php
@@ -123,7 +123,7 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 
 		$install_time = get_option( 'themeisle_companion_install' );
 		$current_time = time();
-		if ( ( $current_time - $install_time ) > 60 ) {
+		if ( ( $current_time - $install_time ) <= 60 ) {
 			update_option( 'obfx_new_user', 'yes' );
 			return true;
 		}

--- a/obfx_modules/beaver-widgets/init.php
+++ b/obfx_modules/beaver-widgets/init.php
@@ -113,12 +113,26 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 *
 	 * @since   2.2.5
 	 * @access  public
+	 * @return bool
 	 */
 	public function load_widgets_modules() {
-		if ( class_exists( 'FLBuilder' ) ) {
-			require_once 'modules/pricing-table/pricing-table.php';
-			require_once 'modules/services/services.php';
-			require_once 'modules/post-grid/post-grid.php';
+		if( ! class_exists( 'FLBuilderModel' ) || ! class_exists( 'FLBuilder' ) ){
+			return false;
 		}
+		$modules_list =  FLBuilderModel::$modules;
+
+		$modules_to_load = array(
+			'pricing-table', 'services', 'post-grid'
+		);
+
+		foreach ( $modules_to_load as $module ){
+			$prefix = '';
+			if ( array_key_exists( $module, $modules_list ) ){
+				$prefix = 'obfx-';
+			}
+			require_once 'modules/' . $module . '/'. $prefix . $module . '.php';
+		}
+		return true;
 	}
+
 }

--- a/obfx_modules/beaver-widgets/init.php
+++ b/obfx_modules/beaver-widgets/init.php
@@ -124,11 +124,11 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 
 		$install_time = get_option( 'themeisle_companion_install' );
 		$current_time = get_option( 'module_check_time' );
-		if( empty( $current_time ) ){
+		if ( empty( $current_time ) ) {
 			$current_time = time();
 			update_option( 'module_check_time', $current_time );
 		}
-		if ( empty( $install_time ) || empty( $current_time ) ){
+		if ( empty( $install_time ) || empty( $current_time ) ) {
 			return false;
 		}
 
@@ -162,7 +162,7 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		);
 
 		$new_user_prefix = '';
-		if ( $is_new_user  === 'yes' ) {
+		if ( $is_new_user === 'yes' ) {
 			$new_user_prefix = 'obfx-';
 		}
 

--- a/obfx_modules/beaver-widgets/init.php
+++ b/obfx_modules/beaver-widgets/init.php
@@ -116,21 +116,23 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 * @return bool
 	 */
 	public function load_widgets_modules() {
-		if( ! class_exists( 'FLBuilderModel' ) || ! class_exists( 'FLBuilder' ) ){
+		if ( ! class_exists( 'FLBuilderModel' ) || ! class_exists( 'FLBuilder' ) ) {
 			return false;
 		}
-		$modules_list =  FLBuilderModel::$modules;
+		$modules_list = FLBuilderModel::$modules;
 
 		$modules_to_load = array(
-			'pricing-table', 'services', 'post-grid'
+			'pricing-table',
+			'services',
+			'post-grid',
 		);
 
-		foreach ( $modules_to_load as $module ){
+		foreach ( $modules_to_load as $module ) {
 			$prefix = '';
-			if ( array_key_exists( $module, $modules_list ) ){
+			if ( array_key_exists( $module, $modules_list ) ) {
 				$prefix = 'obfx-';
 			}
-			require_once 'modules/' . $module . '/'. $prefix . $module . '.php';
+			require_once 'modules/' . $module . '/' . $prefix . $module . '.php';
 		}
 		return true;
 	}

--- a/obfx_modules/beaver-widgets/init.php
+++ b/obfx_modules/beaver-widgets/init.php
@@ -37,7 +37,7 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 * @return bool
 	 */
 	public function enable_module() {
-		$this->is_new_user();
+		$this->check_new_user();
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		return is_plugin_active( 'beaver-builder-lite-version/fl-builder.php' ) || is_plugin_active( 'bb-plugin/fl-builder.php' );
 	}
@@ -116,18 +116,27 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 *
 	 * @return bool
 	 */
-	private function is_new_user() {
-		$is_new_use = get_option( 'obfx_new_user' );
-		if ( ! empty( $is_new_use ) ) {
-			return $is_new_use === 'yes';
+	private function check_new_user() {
+		$is_new_user = get_option( 'obfx_new_user' );
+		if ( $is_new_user === 'yes' ) {
+			return true;
 		}
 
 		$install_time = get_option( 'themeisle_companion_install' );
-		$current_time = time();
+		$current_time = get_option( 'module_check_time' );
+		if( empty( $current_time ) ){
+			$current_time = time();
+			update_option( 'module_check_time', $current_time );
+		}
+		if ( empty( $install_time ) || empty( $current_time ) ){
+			return false;
+		}
+
 		if ( ( $current_time - $install_time ) <= 60 ) {
 			update_option( 'obfx_new_user', 'yes' );
 			return true;
 		}
+
 		update_option( 'obfx_new_user', 'no' );
 		return false;
 	}
@@ -143,6 +152,7 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		if ( ! class_exists( 'FLBuilderModel' ) || ! class_exists( 'FLBuilder' ) ) {
 			return false;
 		}
+		$is_new_user  = get_option( 'obfx_new_user' );
 		$modules_list = FLBuilderModel::$modules;
 
 		$modules_to_load = array(
@@ -152,7 +162,7 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		);
 
 		$new_user_prefix = '';
-		if ( $this->is_new_user() ) {
+		if ( $is_new_user  === 'yes' ) {
 			$new_user_prefix = 'obfx-';
 		}
 

--- a/obfx_modules/beaver-widgets/init.php
+++ b/obfx_modules/beaver-widgets/init.php
@@ -37,6 +37,7 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 * @return bool
 	 */
 	public function enable_module() {
+		$this->is_new_user();
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		return is_plugin_active( 'beaver-builder-lite-version/fl-builder.php' ) || is_plugin_active( 'bb-plugin/fl-builder.php' );
 	}

--- a/obfx_modules/beaver-widgets/init.php
+++ b/obfx_modules/beaver-widgets/init.php
@@ -150,13 +150,14 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 			'post-grid',
 		);
 
-		$prefix = '';
+		$new_user_prefix = '';
 		if ( $this->is_new_user() ) {
-			$prefix = 'obfx-';
+			$new_user_prefix = 'obfx-';
 		}
 
 		foreach ( $modules_to_load as $module ) {
-			if ( array_key_exists( $module, $modules_list ) ) {
+			$prefix = $new_user_prefix;
+			if ( empty( $prefix ) && array_key_exists( $module, $modules_list ) ) {
 				$prefix = 'obfx-';
 			}
 			require_once 'modules/' . $module . '/' . $prefix . $module . '.php';

--- a/obfx_modules/beaver-widgets/init.php
+++ b/obfx_modules/beaver-widgets/init.php
@@ -115,7 +115,7 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 *
 	 * @return bool
 	 */
-	private function is_new_user(){
+	private function is_new_user() {
 		$is_new_use = get_option( 'obfx_new_user' );
 		if ( ! empty( $is_new_use ) ) {
 			return $is_new_use === 'yes';
@@ -151,7 +151,7 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		);
 
 		$prefix = '';
-		if( $this->is_new_user() ) {
+		if ( $this->is_new_user() ) {
 			$prefix = 'obfx-';
 		}
 

--- a/obfx_modules/beaver-widgets/init.php
+++ b/obfx_modules/beaver-widgets/init.php
@@ -108,6 +108,29 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 
 		return true;
 	}
+
+
+	/**
+	 * Check if it's a new user for orbit fox.
+	 *
+	 * @return bool
+	 */
+	private function is_new_user(){
+		$is_new_use = get_option( 'obfx_new_user' );
+		if ( ! empty( $is_new_use ) ) {
+			return $is_new_use === 'yes';
+		}
+
+		$install_time = get_option( 'themeisle_companion_install' );
+		$current_time = time();
+		if ( ( $current_time - $install_time ) > 60 ) {
+			update_option( 'obfx_new_user', 'yes' );
+			return true;
+		}
+		update_option( 'obfx_new_user', 'no' );
+		return false;
+	}
+
 	/**
 	 * Require Beaver Builder modules
 	 *
@@ -127,8 +150,12 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 			'post-grid',
 		);
 
+		$prefix = '';
+		if( $this->is_new_user() ) {
+			$prefix = 'obfx-';
+		}
+
 		foreach ( $modules_to_load as $module ) {
-			$prefix = '';
 			if ( array_key_exists( $module, $modules_list ) ) {
 				$prefix = 'obfx-';
 			}

--- a/obfx_modules/beaver-widgets/modules/post-grid/obfx-post-grid.php
+++ b/obfx_modules/beaver-widgets/modules/post-grid/obfx-post-grid.php
@@ -1,10 +1,14 @@
 <?php
 /**
+ * This file is the same as post-grid.php. Beaver takes the name of the file and make it the id for the widget.
+ * There can't be two identical ID's so if Beaver Widgets Pro plugin is installed it adds a post grid widget,
+ * and the widget we add need to have another id. If we change the id from post-grid to obfx-post-grid,
+ * for users that are using beaver lite and OBFX the widgets will disappear so we need to have both files.
+ *
  * Post grid widget.
  *
  * @package themeisle-companion
  */
-
 // Get the module directory.
 $module_directory = $this->get_dir();
 

--- a/obfx_modules/beaver-widgets/modules/pricing-table/obfx-pricing-table.php
+++ b/obfx_modules/beaver-widgets/modules/pricing-table/obfx-pricing-table.php
@@ -1,0 +1,594 @@
+<?php
+/**
+ * This file is the same as pricing-table.php. Beaver takes the name of the file and make it the id for the widget.
+ * There can't be two identical ID's so if Beaver Widgets Pro plugin is installed it adds a pricing widget,
+ * and the widget we add need to have another id. If we change the id from pricing-table to obfx-pricing-table,
+ * for users that are using beaver lite and OBFX the widgets will disappear so we need to have both files.
+ *
+ * Pricing table module.
+ *
+ * @package themeisle-companion
+ */
+
+// Get the module directory.
+$module_directory = $this->get_dir();
+
+// Include common functions file.
+require_once $module_directory . '/inc/common-functions.php';
+
+// Include custom fields
+require_once $module_directory . '/custom-fields/toggle-field/toggle_field.php';
+
+/**
+ * Class PricingTableModule
+ */
+class PricingTableModule extends FLBuilderModule {
+
+	/**
+	 * Constructor function for the module. You must pass the
+	 * name, description, dir and url in an array to the parent class.
+	 *
+	 * @method __construct
+	 */
+	public function __construct() {
+		parent::__construct(
+			array(
+				'name'          => esc_html__( 'Pricing table', 'themeisle-companion' ),
+				'description'   => esc_html__( 'Pricing Tables are the perfect option when showcasing services you have on offer.', 'themeisle-companion' ),
+				'category'      => esc_html__( 'Orbit Fox Modules', 'themeisle-companion' ),
+				'dir'           => BEAVER_WIDGETS_PATH . 'modules/pricing-table/',
+				'url'           => BEAVER_WIDGETS_URL . 'modules/pricing-table/',
+				'editor_export' => true, // Defaults to true and can be omitted.
+				'enabled'       => true, // Defaults to true and can be omitted.
+			)
+		);
+	}
+}
+
+/**
+ * Register the module and its form settings.
+ */
+FLBuilder::register_module(
+	'PricingTableModule',
+	array(
+		'content'        => array(
+			'title'    => esc_html__( 'Content', 'themeisle-companion' ), // Tab title
+			'sections' => array(
+				'header'     => array(
+					'title'  => esc_html__( 'Plan Header', 'themeisle-companion' ),
+					'fields' => array(
+						'plan_title'        => array(
+							'type'    => 'text',
+							'label'   => esc_html__( 'Title', 'themeisle-companion' ),
+							'default' => esc_html__( 'Plan title', 'themeisle-companion' ),
+							'preview' => array(
+								'type'     => 'text',
+								'selector' => '.obfx-plan-title',
+							),
+						),
+						'plan_title_tag'    => array(
+							'type'    => 'select',
+							'label'   => esc_html__( 'Title tag', 'themeisle-companion' ),
+							'default' => 'h2',
+							'options' => array(
+								'h1' => esc_html__( 'h1', 'themeisle-companion' ),
+								'h2' => esc_html__( 'h2', 'themeisle-companion' ),
+								'h3' => esc_html__( 'h3', 'themeisle-companion' ),
+								'h4' => esc_html__( 'h4', 'themeisle-companion' ),
+								'h5' => esc_html__( 'h5', 'themeisle-companion' ),
+								'h6' => esc_html__( 'h6', 'themeisle-companion' ),
+								'p'  => esc_html__( 'p', 'themeisle-companion' ),
+							),
+						),
+						'plan_subtitle'     => array(
+							'type'    => 'text',
+							'label'   => esc_html__( 'Subtitle', 'themeisle-companion' ),
+							'default' => esc_html__( 'Plan subtitle', 'themeisle-companion' ),
+							'preview' => array(
+								'type'     => 'text',
+								'selector' => '.obfx-plan-subtitle',
+							),
+						),
+						'plan_subtitle_tag' => array(
+							'type'    => 'select',
+							'label'   => esc_html__( 'Subtitle tag', 'themeisle-companion' ),
+							'default' => 'p',
+							'options' => array(
+								'h1' => esc_html__( 'h1', 'themeisle-companion' ),
+								'h2' => esc_html__( 'h2', 'themeisle-companion' ),
+								'h3' => esc_html__( 'h3', 'themeisle-companion' ),
+								'h4' => esc_html__( 'h4', 'themeisle-companion' ),
+								'h5' => esc_html__( 'h5', 'themeisle-companion' ),
+								'h6' => esc_html__( 'h6', 'themeisle-companion' ),
+								'p'  => esc_html__( 'p', 'themeisle-companion' ),
+							),
+						),
+					),
+				),
+				'price'      => array(
+					'title'  => esc_html__( 'Price Tag', 'themeisle-companion' ),
+					'fields' => array(
+						'price'             => array(
+							'type'    => 'text',
+							'label'   => esc_html__( 'Price', 'themeisle-companion' ),
+							'default' => '50',
+							'preview' => array(
+								'type'     => 'text',
+								'selector' => '.obfx-price',
+							),
+						),
+						'currency'          => array(
+							'type'    => 'text',
+							'label'   => esc_html__( 'Currency', 'themeisle-companion' ),
+							'default' => '$',
+							'preview' => array(
+								'type'     => 'text',
+								'selector' => '.obfx-currency',
+							),
+						),
+						'currency_position' => array(
+							'type'    => 'select',
+							'label'   => esc_html__( 'Currency position', 'themeisle-companion' ),
+							'default' => 'after',
+							'options' => array(
+								'before' => esc_html__( 'Before', 'themeisle-companion' ),
+								'after'  => esc_html__( 'After', 'themeisle-companion' ),
+							),
+						),
+						'period'            => array(
+							'type'    => 'text',
+							'label'   => esc_html__( 'Period', 'themeisle-companion' ),
+							'default' => esc_html__( '/month', 'themeisle-companion' ),
+							'preview' => array(
+								'type'     => 'text',
+								'selector' => '.obfx-period',
+							),
+						),
+					),
+				),
+				'features'   => array(
+					'title'  => esc_html__( 'Features list', 'themeisle-companion' ),
+					'fields' => array(
+						'features' => array(
+							'multiple'     => true,
+							'type'         => 'form',
+							'label'        => esc_html__( 'Feature', 'themeisle-companion' ),
+							'form'         => 'feature_field', // ID of a registered form.
+							'preview_text' => 'text', // ID of a field to use for the preview text.
+						),
+					),
+				),
+				'button'     => array(
+					'title'  => esc_html__( 'Button', 'themeisle-companion' ),
+					'fields' => array(
+						'text' => array(
+							'type'    => 'text',
+							'label'   => esc_html__( 'Button text', 'themeisle-companion' ),
+							'default' => esc_html__( 'Button', 'themeisle-companion' ),
+							'preview' => array(
+								'type'     => 'text',
+								'selector' => '.obfx-plan-button',
+							),
+						),
+						'link' => array(
+							'type'  => 'link',
+							'label' => esc_html__( 'Button link', 'themeisle-companion' ),
+						),
+					),
+				),
+				'appearance' => array(
+					'title'  => esc_html__( 'Appearance', 'themeisle-companion' ),
+					'fields' => array(
+						'card_layout'   => array(
+							'type'    => 'obfx_toggle',
+							'label'   => esc_html__( 'Card layout', 'themeisle-companion' ),
+							'default' => 'yes',
+						),
+						'text_position' => array(
+							'type'    => 'select',
+							'label'   => esc_html__( 'Align', 'themeisle-companion' ),
+							'default' => 'center',
+							'options' => array(
+								'center' => esc_html__( 'Center', 'themeisle-companion' ),
+								'left'   => esc_html__( 'Left', 'themeisle-companion' ),
+								'right'  => esc_html__( 'Right', 'themeisle-companion' ),
+							),
+						),
+					),
+				),
+			),
+		),
+		'header_style'   => array(
+			'title'    => esc_html__( 'Header Style', 'themeisle-companion' ),
+			'sections' => array(
+				'header_padding'      => themeisle_four_fields_control(
+					array(
+						'default'           => array(
+							'top'    => 15,
+							'bottom' => 15,
+							'left'   => 0,
+							'right'  => 0,
+						),
+						'selector'          => '.obfx-pricing-header',
+						'field_name_prefix' => '',
+					)
+				),
+				'colors'              => array(
+					'title'  => esc_html__( 'Colors', 'themeisle-companion' ),
+					'fields' => array(
+						'title_color'    => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Title color', 'themeisle-companion' ),
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-pricing-header *:first-child',
+										'property' => 'color',
+									),
+								),
+							),
+						),
+						'subtitle_color' => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Subtitle color', 'themeisle-companion' ),
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-pricing-header *:last-child',
+										'property' => 'color',
+									),
+								),
+							),
+						),
+					),
+				),
+				'title_typography'    => themeisle_typography_settings(
+					array(
+						'title'    => esc_html__( 'Title typography', 'themeisle-companion' ),
+						'prefix'   => 'title_',
+						'selector' => '.obfx-pricing-header *:first-child',
+					)
+				),
+				'subtitle_typography' => themeisle_typography_settings(
+					array(
+						'title'    => esc_html__( 'Subtitle typography', 'themeisle-companion' ),
+						'prefix'   => 'subtitle_',
+						'selector' => '.obfx-pricing-header *:last-child',
+					)
+				),
+				'header_background'   => array(
+					'title'  => esc_html__( 'Background', 'themeisle-companion' ),
+					'fields' => array(
+						'bg_type'              => array(
+							'type'    => 'select',
+							'label'   => esc_html__( 'Type', 'themeisle-companion' ),
+							'default' => 'color',
+							'options' => array(
+								'color'    => esc_html__( 'Color', 'themeisle-companion' ),
+								'image'    => esc_html__( 'Background', 'themeisle-companion' ),
+								'gradient' => esc_html__( 'Gradient', 'themeisle-companion' ),
+							),
+							'toggle'  => array(
+								'color'    => array(
+									'fields' => array( 'header_bg_color' ),
+								),
+								'image'    => array(
+									'fields' => array( 'header_bg_image' ),
+								),
+								'gradient' => array(
+									'fields' => array( 'gradient_color1', 'gradient_color2', 'gradient_orientation' ),
+								),
+							),
+						),
+						'header_bg_color'      => array(
+							'type'       => 'color',
+							'label'      => esc_html__( 'Background color', 'themeisle-companion' ),
+							'show_reset' => true,
+							'preview'    => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-pricing-header',
+										'property' => 'background-color',
+									),
+								),
+							),
+						),
+						'header_bg_image'      => array(
+							'type'        => 'photo',
+							'label'       => esc_html__( 'Photo Field', 'themeisle-companion' ),
+							'show_remove' => true,
+						),
+						'gradient_color1'      => array(
+							'type'       => 'color',
+							'label'      => esc_html__( 'Gradient color 1', 'themeisle-companion' ),
+							'show_reset' => true,
+						),
+						'gradient_color2'      => array(
+							'type'       => 'color',
+							'label'      => esc_html__( 'Gradient color 2', 'themeisle-companion' ),
+							'show_reset' => true,
+						),
+						'gradient_orientation' => array(
+							'type'    => 'select',
+							'label'   => esc_html__( 'Orientation', 'themeisle-companion' ),
+							'default' => 'horizontal',
+							'options' => array(
+								'horizontal'      => esc_html__( 'Horizontal', 'themeisle-companion' ),
+								'vertical'        => esc_html__( 'Vertical', 'themeisle-companion' ),
+								'diagonal_bottom' => esc_html__( 'Diagonal bottom', 'themeisle-companion' ),
+								'diagonal_top'    => esc_html__( 'Diagonal top', 'themeisle-companion' ),
+								'radial'          => esc_html__( 'Radial', 'themeisle-companion' ),
+							),
+						),
+					),
+				),
+			),
+		),
+		'price_style'    => array(
+			'title'    => esc_html__( 'Price Style', 'themeisle-companion' ),
+			'sections' => array(
+				'price_padding'    => themeisle_four_fields_control(
+					array(
+						'default'           => array(
+							'top'    => 15,
+							'bottom' => 15,
+							'left'   => 0,
+							'right'  => 0,
+						),
+						'selector'          => '.obfx-pricing-price',
+						'field_name_prefix' => 'price_',
+					)
+				),
+				'price_colors'     => array(
+					'title'  => esc_html__( 'Colors', 'themeisle-companion' ),
+					'fields' => array(
+						'price_color'    => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Price color', 'themeisle-companion' ),
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-price',
+										'property' => 'color',
+									),
+								),
+							),
+						),
+						'currency_color' => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Currency color', 'themeisle-companion' ),
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-pricing-price sup',
+										'property' => 'color',
+									),
+								),
+							),
+						),
+						'period_color'   => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Period color', 'themeisle-companion' ),
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-period',
+										'property' => 'color',
+									),
+								),
+							),
+						),
+					),
+				),
+				'price_typography' => themeisle_typography_settings(
+					array(
+						'prefix'            => 'price_',
+						'selector'          => '.obfx-pricing-price',
+						'font_size_default' => 40,
+					)
+				),
+			),
+		),
+		'features_style' => array(
+			'title'    => esc_html__( 'Features Style', 'themeisle-companion' ),
+			'sections' => array(
+				'features_padding'   => themeisle_four_fields_control(
+					array(
+						'default'           => array(
+							'top'    => 15,
+							'bottom' => 15,
+							'left'   => 0,
+							'right'  => 0,
+						),
+						'selector'          => '.obfx-pricing-price',
+						'field_name_prefix' => 'features_',
+					)
+				),
+				'features_colors'    => array(
+					'title'  => esc_html__( 'Colors', 'themeisle-companion' ),
+					'fields' => array(
+						'icon_color'    => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Icon color', 'themeisle-companion' ),
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-pricing-feature-content i',
+										'property' => 'color',
+									),
+								),
+							),
+						),
+						'bold_color'    => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Bold text color', 'themeisle-companion' ),
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-pricing-feature-content strong',
+										'property' => 'color',
+									),
+								),
+							),
+						),
+						'feature_color' => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Text color', 'themeisle-companion' ),
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-pricing-feature-content:not(i):not(strong)',
+										'property' => 'color',
+									),
+								),
+							),
+						),
+					),
+				),
+				'feature_typography' => themeisle_typography_settings(
+					array(
+						'prefix'            => 'feature_',
+						'selector'          => '.obfx-pricing-feature-content *',
+						'font_size_default' => 17,
+					)
+				),
+			),
+		),
+		'button_style'   => array(
+			'title'    => esc_html__( 'Button Style', 'themeisle-companion' ),
+			'sections' => array(
+				'button_margins'    => themeisle_four_fields_control(
+					array(
+						'default'           => array(
+							'top'    => 15,
+							'bottom' => 15,
+							'left'   => 0,
+							'right'  => 0,
+						),
+						'selector'          => '.obfx-plan-bottom',
+						'field_name_prefix' => 'button_margin_',
+						'type'              => 'margin',
+					)
+				),
+				'button_padding'    => themeisle_four_fields_control(
+					array(
+						'default'           => array(
+							'top'    => 6,
+							'bottom' => 6,
+							'left'   => 12,
+							'right'  => 12,
+						),
+						'selector'          => '.obfx-plan-button',
+						'field_name_prefix' => 'button_padding_',
+					)
+				),
+				'button_colors'     => array(
+					'title'  => esc_html__( 'Colors', 'themeisle-companion' ),
+					'fields' => array(
+						'button_text_color'       => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Text', 'themeisle-companion' ),
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-plan-button',
+										'property' => 'color',
+									),
+								),
+							),
+						),
+						'button_text_color_hover' => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Text on hover', 'themeisle-companion' ),
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-plan-button:hover',
+										'property' => 'color',
+									),
+								),
+							),
+						),
+						'button_bg_color'         => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Button background', 'themeisle-companion' ),
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-plan-button',
+										'property' => 'background-color',
+									),
+								),
+							),
+						),
+						'button_bg_color_hover'   => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Button background on hover', 'themeisle-companion' ),
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-plan-button:hover',
+										'property' => 'background-color',
+									),
+								),
+							),
+						),
+					),
+				),
+				'button_typography' => themeisle_typography_settings(
+					array(
+						'prefix'            => 'button_',
+						'selector'          => '.obfx-plan-button',
+						'font_size_default' => 15,
+					)
+				),
+			),
+		),
+	)
+);
+
+
+FLBuilder::register_settings_form(
+	'feature_field',
+	array(
+		'title' => __( 'Feature', 'themeisle-companion' ),
+		'tabs'  => array(
+			'general' => array(
+				'title'    => esc_html__( 'General', 'themeisle-companion' ),
+				'sections' => array(
+					'general' => array(
+						'title'  => '',
+						'fields' => array(
+							'bold_text' => array(
+								'type'  => 'text',
+								'label' => esc_html__( 'Bold text', 'themeisle-companion' ),
+							),
+							'text'      => array(
+								'type'  => 'text',
+								'label' => esc_html__( 'Text', 'themeisle-companion' ),
+							),
+							'icon'      => array(
+								'type'        => 'icon',
+								'label'       => esc_html__( 'Icon', 'themeisle-companion' ),
+								'show_remove' => true,
+							),
+						),
+					),
+				),
+			),
+		),
+	)
+);

--- a/obfx_modules/beaver-widgets/modules/services/obfx-services.php
+++ b/obfx_modules/beaver-widgets/modules/services/obfx-services.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * This file is the same as services.php. Beaver takes the name of the file and make it the id for the widget.
+ * There can't be two identical ID's so if Beaver Widgets Pro plugin is installed it adds a services widget,
+ * and  the widget we add need to have another id. If we change the id from services to obfx-services, for users
+ * that are using beaver lite and OBFX the widgets will disappear so we need to have both files.
+ *
+ * Services module.
+ *
+ * @package themeisle-companion
+ */
+
+// Get the module directory.
+$module_directory = $this->get_dir();
+
+// Include common functions file.
+require_once $module_directory . '/inc/common-functions.php';
+
+// Include custom fields
+require_once $module_directory . '/custom-fields/toggle-field/toggle_field.php';
+
+/**
+ * Class PricingTableModule
+ */
+class ServicesModule extends FLBuilderModule {
+
+	/**
+	 * Constructor function for the module. You must pass the
+	 * name, description, dir and url in an array to the parent class.
+	 *
+	 * @method __construct
+	 */
+	public function __construct() {
+		parent::__construct(
+			array(
+				'name'        => esc_html__( 'Services', 'themeisle-companion' ),
+				'description' => esc_html__( 'An overview of the products or services.', 'themeisle-companion' ),
+				'category'    => esc_html__( 'Orbit Fox Modules', 'themeisle-companion' ),
+				'dir'         => BEAVER_WIDGETS_PATH . 'modules/services/',
+				'url'         => BEAVER_WIDGETS_URL . 'modules/services/',
+			)
+		);
+	}
+}
+
+/**
+ * Register the module and its form settings.
+ */
+FLBuilder::register_module(
+	'ServicesModule',
+	array(
+		'content'       => array(
+			'title'    => esc_html__( 'Content', 'themeisle-companion' ), // Tab title
+			'sections' => array(
+				'content' => array(
+					'title'  => '',
+					'fields' => array(
+						'services'         => array(
+							'multiple'     => true,
+							'type'         => 'form',
+							'label'        => esc_html__( 'Service', 'themeisle-companion' ),
+							'form'         => 'service_content', // ID of a registered form.
+							'preview_text' => 'title', // ID of a field to use for the preview text.
+						),
+						'column_number'    => array(
+							'type'    => 'select',
+							'label'   => esc_html__( 'Number of columns', 'themeisle-companion' ),
+							'default' => '3',
+							'options' => array(
+								'1' => esc_html__( '1', 'themeisle-companion' ),
+								'2' => esc_html__( '2', 'themeisle-companion' ),
+								'3' => esc_html__( '3', 'themeisle-companion' ),
+								'4' => esc_html__( '4', 'themeisle-companion' ),
+								'5' => esc_html__( '5', 'themeisle-companion' ),
+							),
+						),
+						'card_layout'      => array(
+							'type'    => 'obfx_toggle',
+							'label'   => esc_html__( 'Card layout', 'themeisle-companion' ),
+							'default' => 'yes',
+						),
+						'background_color' => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Background color', 'themeisle-companion' ),
+							'default' => 'ffffff',
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-service',
+										'property' => 'background',
+									),
+								),
+							),
+						),
+
+					),
+				),
+			),
+		),
+		'icon_style'    => array(
+			'title'    => esc_html__( 'Icon style', 'themeisle-companion' ), // Tab title
+			'sections' => array(
+				'font'         => array(
+					'title'  => esc_html__( 'General', 'themeisle-companion' ),
+					'fields' => array(
+						'icon_position' => array(
+							'type'    => 'select',
+							'label'   => esc_html__( 'Position', 'themeisle-companion' ),
+							'default' => 'center',
+							'options' => array(
+								'left'   => esc_html__( 'Left', 'themeisle-companion' ),
+								'center' => esc_html__( 'Center', 'themeisle-companion' ),
+								'right'  => esc_html__( 'Right', 'themeisle-companion' ),
+							),
+						),
+						'icon_size'     => array(
+							'type'        => 'text',
+							'label'       => esc_html__( 'Size', 'themeisle-companion' ),
+							'description' => esc_html__( 'px', 'themeisle-companion' ),
+							'default'     => '45',
+							'maxlength'   => '3',
+							'size'        => '4',
+							'preview'     => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-service-icon',
+										'property' => 'font-size',
+										'unit'     => 'px',
+									),
+								),
+							),
+						),
+					),
+				),
+				'icon_padding' => themeisle_four_fields_control(
+					array(
+						'default'           => array(
+							'top'    => 30,
+							'bottom' => 15,
+							'left'   => 25,
+							'right'  => 25,
+						),
+						'selector'          => '.obfx-service-icon',
+						'field_name_prefix' => 'icon_',
+					)
+				),
+			),
+		),
+		'title_style'   => array(
+			'title'    => esc_html__( 'Title style', 'themeisle-companion' ),
+			'sections' => array(
+				'general'    => array(
+					'title'  => esc_html__( 'General', 'themeisle-companion' ),
+					'fields' => array(
+						'title_color' => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Color', 'themeisle-companion' ),
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-service-title',
+										'property' => 'color',
+									),
+								),
+							),
+						),
+					),
+				),
+				'typography' => themeisle_typography_settings(
+					array(
+						'prefix'   => 'title_',
+						'selector' => '.obfx-service-title',
+					)
+				),
+			),
+		),
+		'content_style' => array(
+			'title'    => esc_html__( 'Content style', 'themeisle-companion' ),
+			'sections' => array(
+				'general'    => array(
+					'title'  => esc_html__( 'General', 'themeisle-companion' ),
+					'fields' => array(
+						'content_alignment' => array(
+							'type'    => 'select',
+							'label'   => esc_html__( 'Alignment', 'themeisle-companion' ),
+							'default' => 'center',
+							'options' => array(
+								'left'   => esc_html__( 'Left', 'themeisle-companion' ),
+								'center' => esc_html__( 'Center', 'themeisle-companion' ),
+								'right'  => esc_html__( 'Right', 'themeisle-companion' ),
+							),
+						),
+						'content_color'     => array(
+							'type'    => 'color',
+							'label'   => esc_html__( 'Color', 'themeisle-companion' ),
+							'preview' => array(
+								'type'  => 'css',
+								'rules' => array(
+									array(
+										'selector' => '.obfx-service-content',
+										'property' => 'color',
+									),
+								),
+							),
+						),
+					),
+				),
+				'typography' => themeisle_typography_settings(
+					array(
+						'prefix'   => 'content_',
+						'selector' => '.obfx-service-content',
+					)
+				),
+			),
+		),
+	)
+);
+
+FLBuilder::register_settings_form(
+	'service_content',
+	array(
+		'title' => __( 'Service', 'themeisle-companion' ),
+		'tabs'  => array(
+			'general' => array(
+				'title'    => esc_html__( 'General', 'themeisle-companion' ),
+				'sections' => array(
+					'general' => array(
+						'title'  => '',
+						'fields' => array(
+							'title'      => array(
+								'type'  => 'text',
+								'label' => esc_html__( 'Title', 'themeisle-companion' ),
+							),
+							'text'       => array(
+								'type'  => 'textarea',
+								'label' => esc_html__( 'Text', 'themeisle-companion' ),
+								'rows'  => '6',
+							),
+							'icon'       => array(
+								'type'        => 'icon',
+								'label'       => esc_html__( 'Icon', 'themeisle-companion' ),
+								'show_remove' => true,
+							),
+							'icon_color' => array(
+								'type'    => 'color',
+								'label'   => esc_html__( 'Icon color', 'themeisle-companion' ),
+								'default' => 'd6d6d6',
+							),
+							'link'       => array(
+								'type'  => 'link',
+								'label' => esc_html__( 'Link to', 'themeisle-companion' ),
+							),
+						),
+					),
+				),
+			),
+		),
+	)
+);

--- a/obfx_modules/mystock-import/init.php
+++ b/obfx_modules/mystock-import/init.php
@@ -214,12 +214,12 @@ class Mystock_Import_OBFX_Module extends Orbit_Fox_Module_Abstract {
 
 			$this->localized = array(
 				'script' => array(
-					'ajaxurl'          => admin_url( 'admin-ajax.php' ),
-					'nonce'            => wp_create_nonce( $this->slug . filter_input( INPUT_SERVER, 'REMOTE_ADDR', FILTER_VALIDATE_IP ) ),
-					'slug'             => $this->slug,
-					'api_key'          => self::API_KEY,
-					'user_id'          => self::USER_ID,
-					'per_page'         => 20,
+					'ajaxurl'  => admin_url( 'admin-ajax.php' ),
+					'nonce'    => wp_create_nonce( $this->slug . filter_input( INPUT_SERVER, 'REMOTE_ADDR', FILTER_VALIDATE_IP ) ),
+					'slug'     => $this->slug,
+					'api_key'  => self::API_KEY,
+					'user_id'  => self::USER_ID,
+					'per_page' => 20,
 				),
 			);
 


### PR DESCRIPTION
The issue appears when using Obfx and Beaver Builder ( the pro version ).
Beaver gets the id of the widget from the file name. The problem was that we named the features, post-grid and pricing widgets the same as they did in their pro version.
A quick solution would be to rename the files but then the widgets that were added by users in the lite version of the Beaver Builder would disappear.
What I did was to duplicate the file and prefix it with "obfx-" and then check the widgets that are already registered. If pricing-table or features or post-grid widgets exist ( they do in pro plugin ) then I register obfx-pricing-table, obfx-features, obfx-post-grid widget.
This way, no one is affected. Users that are using Obfx with Beaver lite have the same widgets and users that are using Beaver Pro won't get the error and now they can use our widgets too ( because of the name conflict, those widgets form obfx were not available ).
The only downside is that when someone who had beaver lite and used our widget upgrade to beaver pro, the widgets will disappear but that's the same behavior as we have now.

Closes #313.