### PR TITLE
chore: Adaptation for the new dashboard page in Neve

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "codeinwp/themeisle-content-forms": "master",
     "codeinwp/themeisle-sdk": "^3.1",
     "codeinwp/gutenberg-blocks": "^1.3",
-    "codeinwp/ti-onboarding": "^1.8"
+    "codeinwp/themeisle-onboarding": "master"
   },
   "autoload": {
     "files": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "175fb2141c32cdef8fe0127d3dc4956e",
+    "content-hash": "e5a481b4aa426d3424cada1f218fbb13",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -251,6 +251,49 @@
             "time": "2020-04-22T07:45:52+00:00"
         },
         {
+            "name": "codeinwp/themeisle-onboarding",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Codeinwp/themeisle-onboarding.git",
+                "reference": "cf8812607ef1c17e5da2fc2ba75727c294eff043"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-onboarding/zipball/cf8812607ef1c17e5da2fc2ba75727c294eff043",
+                "reference": "cf8812607ef1c17e5da2fc2ba75727c294eff043",
+                "shasum": ""
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5.0 || ^0.6.0",
+                "squizlabs/php_codesniffer": "^3.1",
+                "wp-coding-standards/wpcs": "^1.0.0 || ^2.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "installer-disable": "true"
+            },
+            "autoload": {
+                "psr-4": {
+                    "TIOB\\": "includes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "ThemeIsle team",
+                    "email": "friends@themeisle.com",
+                    "homepage": "https://themeisle.com"
+                }
+            ],
+            "description": "ThemeIsle Onboarding Module.",
+            "homepage": "https://github.com/Codeinwp/themeisle-onboarding",
+            "time": "2020-04-22T13:32:46+00:00"
+        },
+        {
             "name": "codeinwp/themeisle-sdk",
             "version": "3.2.8",
             "source": {
@@ -287,41 +330,6 @@
                 "wordpress"
             ],
             "time": "2020-03-24T16:54:54+00:00"
-        },
-        {
-            "name": "codeinwp/ti-onboarding",
-            "version": "1.8.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Codeinwp/ti-onboarding.git",
-                "reference": "03d872013eeef2a7e6b088f4af5a36f5d61b56d8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/ti-onboarding/zipball/03d872013eeef2a7e6b088f4af5a36f5d61b56d8",
-                "reference": "03d872013eeef2a7e6b088f4af5a36f5d61b56d8",
-                "shasum": ""
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5.0 || ^0.6.0",
-                "squizlabs/php_codesniffer": "^3.1",
-                "wp-coding-standards/wpcs": "^1.0.0 || ^2.0.0"
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "ThemeIsle team",
-                    "email": "friends@themeisle.com",
-                    "homepage": "https://themeisle.com"
-                }
-            ],
-            "description": "Onboarding for themeisle themes.",
-            "homepage": "https://github.com/Codeinwp/ti-onboarding",
-            "time": "2020-02-03T11:53:11+00:00"
         },
         {
             "name": "guzzlehttp/psr7",

--- a/core/includes/class-orbit-fox.php
+++ b/core/includes/class-orbit-fox.php
@@ -225,7 +225,7 @@ class Orbit_Fox {
 			return;
 		}
 
-		$library = OBX_PATH . '/vendor/codeinwp/ti-onboarding/load.php';
+		$library = OBX_PATH . '/vendor/codeinwp/themeisle-onboarding/load.php';
 
 		if ( ! is_file( $library ) ) {
 			return;
@@ -235,11 +235,11 @@ class Orbit_Fox {
 		add_filter(
 			'themeisle_site_import_uri',
 			function () {
-				return OBFX_URL . Themeisle_Onboarding::OBOARDING_PATH;
+				return OBFX_URL . \TIOB\Main::OBOARDING_PATH;
 			}
 		);
 
-		\Themeisle_Onboarding::instance();
+		\TIOB\Main::instance();
 
 	}
 


### PR DESCRIPTION
Changes the fallback [ti-onboarding](https://github.com/codeinwp/ti-onboarding) library with the new version found [here](https://github.com/codeinwp/themeisle-onboarding).

This should be used only as a fallback when the library is not available in the theme. 

It can be tested by removing the new library and load.php path from the theme `composer.json`, deleting the `composer.lock` file and run `composer install`.

Then the library should be picked from themeisle-companion (this plugin).

ref: Codeinwp/neve-pro-addon#605