### PR TITLE
Fix/localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##### [Version 2.9.9](https://github.com/Codeinwp/themeisle-companion/compare/v2.9.8...v2.9.9) (2020-06-05)
+
+New Header/Footer Scripts module
+
 ##### [Version 2.9.8](https://github.com/Codeinwp/themeisle-companion/compare/v2.9.7...v2.9.8) (2020-04-28)
 
 - Fixed importing multiple photos and better error handling in the Mystock module

--- a/core/app/abstract/class-orbit-fox-module-abstract.php
+++ b/core/app/abstract/class-orbit-fox-module-abstract.php
@@ -557,8 +557,6 @@ abstract class Orbit_Fox_Module_Abstract {
 	 * @param   string $prefix The string to prefix in the enqueued name.
 	 */
 	private function set_scripts( $enqueue, $prefix ) {
-		$sanitized = str_replace( ' ', '-', strtolower( $this->name ) );
-
 		$module_dir = $this->slug;
 
 		if ( ! empty( $enqueue ) ) {
@@ -582,7 +580,7 @@ abstract class Orbit_Fox_Module_Abstract {
 					if ( ! filter_var( $url, FILTER_VALIDATE_URL ) === false ) {
 						$resource = $url;
 					}
-					$id                = 'obfx-module-' . $prefix . '-js-' . $sanitized . '-' . $order;
+					$id                = 'obfx-module-' . $prefix . '-js-' . $module_dir . '-' . $order;
 					$map[ $file_name ] = $id;
 
 					wp_enqueue_script(
@@ -597,7 +595,7 @@ abstract class Orbit_Fox_Module_Abstract {
 					if ( array_key_exists( $file_name, $this->localized ) ) {
 						wp_localize_script(
 							$id,
-							str_replace( '-', '_', $sanitized ),
+							str_replace( '-', '_', $module_dir ),
 							$this->localized[ $file_name ]
 						);
 					}

--- a/core/includes/class-orbit-fox.php
+++ b/core/includes/class-orbit-fox.php
@@ -69,7 +69,7 @@ class Orbit_Fox {
 
 		$this->plugin_name = 'orbit-fox';
 
-		$this->version = '2.9.8';
+		$this->version = '2.9.9';
 
 		$this->load_dependencies();
 		$this->set_locale();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "themeisle-companion",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "themeisle-companion",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "description": "Orbit Fox",
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,13 @@ Activating the Orbit Fox plugin is just like any other plugin. If you've uploade
 
 ## Changelog ##
 
+##### [Version 2.9.9](https://github.com/Codeinwp/themeisle-companion/compare/v2.9.8...v2.9.9) (2020-06-05)
+
+New Header/Footer Scripts module
+
+
+
+
 ##### [Version 2.9.8](https://github.com/Codeinwp/themeisle-companion/compare/v2.9.7...v2.9.8) (2020-04-28)
 
 - Fixed importing multiple photos and better error handling in the Mystock module

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,13 @@ Activating the Orbit Fox plugin is just like any other plugin. If you've uploade
 
 == Changelog ==
 
+##### [Version 2.9.9](https://github.com/Codeinwp/themeisle-companion/compare/v2.9.8...v2.9.9) (2020-06-05)
+
+New Header/Footer Scripts module
+
+
+
+
 ##### [Version 2.9.8](https://github.com/Codeinwp/themeisle-companion/compare/v2.9.7...v2.9.8) (2020-04-28)
 
 - Fixed importing multiple photos and better error handling in the Mystock module

--- a/themeisle-companion.php
+++ b/themeisle-companion.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Orbit Fox Companion
  * Plugin URI:        https://orbitfox.com/
  * Description:       This swiss-knife plugin comes with a quality template library, menu/sharing icons modules, Gutenberg blocks, and newly added Elementor/BeaverBuilder page builder widgets on each release.
- * Version:           2.9.8
+ * Version:           2.9.9
  * Author:            Themeisle
  * Author URI:        https://orbitfox.com/
  * License:           GPL-2.0+


### PR DESCRIPTION
The object_name parameter from wp_localize_script was variable because we used the module name when generating it and not the module slug. The module name is translatable so if someone translates the "Menu icon" string with "Iconos De Menú", the object_name will be "iconos_de_menú" and in js, we're looking for "menu_icons" object.