### PR TITLE
Added notice for Neve Pro in the page builder module

### DIFF
--- a/dashboard/src/components/ModuleCard.js
+++ b/dashboard/src/components/ModuleCard.js
@@ -6,6 +6,7 @@ import { requestData } from '../utils/rest';
 import { Dashicon, ExternalLink, ToggleControl } from '@wordpress/components';
 import { renderToString, useContext, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 
 const { root, toggleStateRoute, options } = obfxDash;
 
@@ -59,6 +60,15 @@ const ModuleCard = ({ slug, details }) => {
 
 	const renderDescription = (description) => {
 		const elements = [];
+		if (description.indexOf('neve-pro-notice') >= 0) {
+			return (
+				<p
+					className="description"
+					dangerouslySetInnerHTML={{ __html: description }}
+				/>
+			);
+		}
+
 		while (description.indexOf('<a') >= 0) {
 			const start = description.indexOf('<a');
 			const end = description.indexOf('</a>');
@@ -92,8 +102,13 @@ const ModuleCard = ({ slug, details }) => {
 		);
 	};
 
+	const isActive = moduleStatus[slug] && moduleStatus[slug].active !== undefined
+		? moduleStatus[slug].active
+		: activeDefault;
+	const classes = classnames('module-card', {'active': isActive});
+
 	return (
-		<div className="module-card">
+		<div className={classes}>
 			<div className="module-card-header">
 				<h3 className="title">{details.name}</h3>
 				<div className="toggle-wrap">
@@ -105,12 +120,7 @@ const ModuleCard = ({ slug, details }) => {
 						/>
 					)}
 					<ToggleControl
-						checked={
-							moduleStatus[slug] &&
-							moduleStatus[slug].active !== undefined
-								? moduleStatus[slug].active
-								: activeDefault
-						}
+						checked={isActive}
 						onChange={updateModuleStatus}
 					/>
 				</div>
@@ -118,9 +128,7 @@ const ModuleCard = ({ slug, details }) => {
 			<div className="module-card-content">
 				{renderDescription(details.description)}
 			</div>
-			{moduleStatus[slug] &&
-				moduleStatus[slug].active &&
-				options[slug].length > 0 && <ModuleSettings slug={slug} />}
+			{isActive && options[slug].length > 0 && <ModuleSettings slug={slug} />}
 		</div>
 	);
 };

--- a/dashboard/src/scss/components/_module-card.scss
+++ b/dashboard/src/scss/components/_module-card.scss
@@ -39,6 +39,44 @@
     }
   }
 
+  &.active .neve-pro-notice {
+    background-color: $obfx-purple;
+    color: #fff;
+    padding: 15px 22px;
+    margin-top: 10px;
+    border-radius: 6px;
+
+    display: flex;
+    justify-content: space-between;
+
+    a {
+      background-color: inherit;
+      color: inherit;
+      border: 2px solid #fff;
+      border-radius: 2px;
+      padding: 0 20px;
+      text-decoration: none;
+
+      display: flex;
+      align-items: center;
+    }
+
+    p {
+      font-size: 15px;
+      margin: 0.75em 0;
+    }
+  }
+
+  .neve-pro-notice {
+    display: none;
+    animation: .5s notice-appear;
+
+    a {
+      opacity: 0;
+      animation: .2s .3s forwards content-appear;
+    }
+  }
+
   .module-card-content {
     padding: 20px;
 
@@ -48,4 +86,14 @@
       color: #616161;
     }
   }
+}
+
+@keyframes notice-appear {
+  from { height: 0; }
+  to { height: 45px; }
+}
+
+@keyframes content-appear {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }

--- a/obfx_modules/beaver-widgets/init.php
+++ b/obfx_modules/beaver-widgets/init.php
@@ -24,8 +24,13 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 */
 	public function __construct() {
 		parent::__construct();
-		$this->name           = __( 'Page builder widgets', 'themeisle-companion' );
-		$this->description    = __( 'Adds widgets to the most popular builders: Elementor or Beaver. More to come!', 'themeisle-companion' );
+		$this->name        = __( 'Page builder widgets', 'themeisle-companion' );
+		$this->description = __( 'Adds widgets to the most popular builders: Elementor or Beaver. More to come!', 'themeisle-companion' );
+
+		if ( wp_get_theme()->get( 'Name' ) === 'Neve' && ! is_plugin_active( 'neve-pro-addon/neve-pro-addon.php' ) ) {
+			$this->description .= '<div class="neve-pro-notice"><p>You can get access to <b>10+ more Elementor and Gutenberg widgets</b>, including Instagram integration, display conditions and more in <b>Neve PRO</b>.</p><a class="notice-cta" target="_blank" href="https://themeisle.com/themes/neve/upgrade/?utm_medium=dashboard&utm_source=pagebuildermodule&utm_campaign=orbitfox"><b>Learn more</b></a></div>';
+		}
+
 		$this->active_default = true;
 	}
 

--- a/obfx_modules/elementor-widgets/init.php
+++ b/obfx_modules/elementor-widgets/init.php
@@ -32,7 +32,7 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		$this->name        = __( 'Page builder widgets', 'themeisle-companion' );
 		$this->description = __( 'Adds widgets to the most popular builders: Elementor or Beaver. More to come!', 'themeisle-companion' );
 
-		if ( wp_get_theme()->get( 'Name' ) === 'Neve' && ! is_plugin_active( 'neve-pro-addon/neve-pro-addon.php' ) ) {
+		if ( self::should_add_placeholders() ) {
 			$this->description .=
 				'<div class="neve-pro-notice">
 					<p>' .


### PR DESCRIPTION
If Neve is active and the user is not pro, a notice is added in the Page Builder module's description.

### Test instructions
- The notice should appear in the description of the page builder module that is displayed when Elementor is active
- It should appear only if Neve is active and Neve Pro is not active

[Codeinwp/neve-pro-addon#1741](https://github.com/Codeinwp/neve-pro-addon/issues/1741)