### PR TITLE
Add placeholders for neve

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           php-version: '7.1'
           extensions: simplexml
+          tools: composer:v1
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Get Composer Cache Directory

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           php-version: '7.1'
           extensions: simplexml
-          tools: composer:v2.1
+          tools: composer:v1
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Get Composer Cache Directory

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           php-version: '7.1'
           extensions: simplexml
-          tools: composer:v1
+          tools: composer:v2.1
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Get Composer Cache Directory

--- a/composer.lock
+++ b/composer.lock
@@ -78,12 +78,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/elementor-extra-widgets.git",
-                "reference": "2894a02bd940b42038f0e097754498a1169b15b1"
+                "reference": "d3122da70b1e4cc75550ca5a3a6da9f619631f76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/elementor-extra-widgets/zipball/2894a02bd940b42038f0e097754498a1169b15b1",
-                "reference": "2894a02bd940b42038f0e097754498a1169b15b1",
+                "url": "https://api.github.com/repos/Codeinwp/elementor-extra-widgets/zipball/d3122da70b1e4cc75550ca5a3a6da9f619631f76",
+                "reference": "d3122da70b1e4cc75550ca5a3a6da9f619631f76",
                 "shasum": ""
             },
             "default-branch": true,
@@ -109,7 +109,7 @@
                 "issues": "https://github.com/Codeinwp/elementor-extra-widgets/issues",
                 "source": "https://github.com/Codeinwp/elementor-extra-widgets/tree/master"
             },
-            "time": "2021-08-02T12:23:30+00:00"
+            "time": "2021-12-21T19:16:26+00:00"
         },
         {
             "name": "codeinwp/full-width-page-templates",
@@ -1350,5 +1350,5 @@
     "platform-overrides": {
         "php": "5.6"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -153,16 +153,16 @@
         },
         {
             "name": "codeinwp/gutenberg-blocks",
-            "version": "1.6.9",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/gutenberg-blocks.git",
-                "reference": "c58fc700fe616d8b4f6029c109a869257d6daeed"
+                "reference": "0f71c8754ae6585171a3013dea7131b2fbfec0c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/gutenberg-blocks/zipball/c58fc700fe616d8b4f6029c109a869257d6daeed",
-                "reference": "c58fc700fe616d8b4f6029c109a869257d6daeed",
+                "url": "https://api.github.com/repos/Codeinwp/gutenberg-blocks/zipball/0f71c8754ae6585171a3013dea7131b2fbfec0c7",
+                "reference": "0f71c8754ae6585171a3013dea7131b2fbfec0c7",
                 "shasum": ""
             },
             "require": {
@@ -196,9 +196,10 @@
             "homepage": "https://github.com/Codeinwp/gutenberg-blocks",
             "support": {
                 "issues": "https://github.com/Codeinwp/gutenberg-blocks/issues",
-                "source": "https://github.com/Codeinwp/gutenberg-blocks/tree/v1.6.9"
+                "source": "https://github.com/Codeinwp/gutenberg-blocks/tree/v1.7.0"
             },
-            "time": "2021-07-02T20:24:47+00:00"
+            "abandoned": true,
+            "time": "2021-10-10T20:03:48+00:00"
         },
         {
             "name": "codeinwp/templates-directory",
@@ -332,16 +333,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.8.2",
+            "version": "1.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "dc960a912984efb74d0a90222870c72c87f10c91"
+                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dc960a912984efb74d0a90222870c72c87f10c91",
-                "reference": "dc960a912984efb74d0a90222870c72c87f10c91",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
+                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
                 "shasum": ""
             },
             "require": {
@@ -379,12 +380,33 @@
             ],
             "authors": [
                 {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
                 },
                 {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
                     "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
                     "homepage": "https://github.com/Tobion"
                 }
             ],
@@ -401,9 +423,23 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/1.8.2"
+                "source": "https://github.com/guzzle/psr7/tree/1.8.3"
             },
-            "time": "2021-04-26T09:17:50+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-05T13:56:00+00:00"
         },
         {
             "name": "mailerlite/mailerlite-api-v2-php-sdk",
@@ -1237,16 +1273,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.0",
+            "version": "3.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
                 "shasum": ""
             },
             "require": {
@@ -1289,7 +1325,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-04-09T00:54:41+00:00"
+            "time": "2021-12-12T21:44:58+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -78,12 +78,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/elementor-extra-widgets.git",
-                "reference": "c6121466d107952821d35bec364983a88fbddab5"
+                "reference": "2894a02bd940b42038f0e097754498a1169b15b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/elementor-extra-widgets/zipball/c6121466d107952821d35bec364983a88fbddab5",
-                "reference": "c6121466d107952821d35bec364983a88fbddab5",
+                "url": "https://api.github.com/repos/Codeinwp/elementor-extra-widgets/zipball/2894a02bd940b42038f0e097754498a1169b15b1",
+                "reference": "2894a02bd940b42038f0e097754498a1169b15b1",
                 "shasum": ""
             },
             "default-branch": true,
@@ -109,7 +109,7 @@
                 "issues": "https://github.com/Codeinwp/elementor-extra-widgets/issues",
                 "source": "https://github.com/Codeinwp/elementor-extra-widgets/tree/master"
             },
-            "time": "2021-12-22T11:09:33+00:00"
+            "time": "2021-08-02T12:23:30+00:00"
         },
         {
             "name": "codeinwp/full-width-page-templates",
@@ -153,16 +153,16 @@
         },
         {
             "name": "codeinwp/gutenberg-blocks",
-            "version": "1.7.0",
+            "version": "1.6.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/gutenberg-blocks.git",
-                "reference": "0f71c8754ae6585171a3013dea7131b2fbfec0c7"
+                "reference": "c58fc700fe616d8b4f6029c109a869257d6daeed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/gutenberg-blocks/zipball/0f71c8754ae6585171a3013dea7131b2fbfec0c7",
-                "reference": "0f71c8754ae6585171a3013dea7131b2fbfec0c7",
+                "url": "https://api.github.com/repos/Codeinwp/gutenberg-blocks/zipball/c58fc700fe616d8b4f6029c109a869257d6daeed",
+                "reference": "c58fc700fe616d8b4f6029c109a869257d6daeed",
                 "shasum": ""
             },
             "require": {
@@ -196,10 +196,9 @@
             "homepage": "https://github.com/Codeinwp/gutenberg-blocks",
             "support": {
                 "issues": "https://github.com/Codeinwp/gutenberg-blocks/issues",
-                "source": "https://github.com/Codeinwp/gutenberg-blocks/tree/v1.7.0"
+                "source": "https://github.com/Codeinwp/gutenberg-blocks/tree/v1.6.9"
             },
-            "abandoned": true,
-            "time": "2021-10-10T20:03:48+00:00"
+            "time": "2021-07-02T20:24:47+00:00"
         },
         {
             "name": "codeinwp/templates-directory",
@@ -293,16 +292,16 @@
         },
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.2.22",
+            "version": "3.2.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "394d0f27e17dab350efa7e91bffff31f4b451fec"
+                "reference": "cafd016b61ec0928c0234e312046782a77c14318"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/394d0f27e17dab350efa7e91bffff31f4b451fec",
-                "reference": "394d0f27e17dab350efa7e91bffff31f4b451fec",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/cafd016b61ec0928c0234e312046782a77c14318",
+                "reference": "cafd016b61ec0928c0234e312046782a77c14318",
                 "shasum": ""
             },
             "require-dev": {
@@ -327,22 +326,22 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.22"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.21"
             },
-            "time": "2021-10-27T10:27:45+00:00"
+            "time": "2021-06-30T10:55:18+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.8.3",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85"
+                "reference": "dc960a912984efb74d0a90222870c72c87f10c91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
-                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dc960a912984efb74d0a90222870c72c87f10c91",
+                "reference": "dc960a912984efb74d0a90222870c72c87f10c91",
                 "shasum": ""
             },
             "require": {
@@ -380,33 +379,12 @@
             ],
             "authors": [
                 {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                },
-                {
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
                 },
                 {
-                    "name": "George Mponos",
-                    "email": "gmponos@gmail.com",
-                    "homepage": "https://github.com/gmponos"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
-                },
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com",
-                    "homepage": "https://github.com/sagikazarmark"
-                },
-                {
                     "name": "Tobias Schultze",
-                    "email": "webmaster@tubo-world.de",
                     "homepage": "https://github.com/Tobion"
                 }
             ],
@@ -423,23 +401,9 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/1.8.3"
+                "source": "https://github.com/guzzle/psr7/tree/1.8.2"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/Nyholm",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-10-05T13:56:00+00:00"
+            "time": "2021-04-26T09:17:50+00:00"
         },
         {
             "name": "mailerlite/mailerlite-api-v2-php-sdk",
@@ -1273,16 +1237,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.2",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
@@ -1325,7 +1289,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-12-12T21:44:58+00:00"
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -1386,5 +1350,5 @@
     "platform-overrides": {
         "php": "5.6"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -78,12 +78,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/elementor-extra-widgets.git",
-                "reference": "2894a02bd940b42038f0e097754498a1169b15b1"
+                "reference": "c6121466d107952821d35bec364983a88fbddab5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/elementor-extra-widgets/zipball/2894a02bd940b42038f0e097754498a1169b15b1",
-                "reference": "2894a02bd940b42038f0e097754498a1169b15b1",
+                "url": "https://api.github.com/repos/Codeinwp/elementor-extra-widgets/zipball/c6121466d107952821d35bec364983a88fbddab5",
+                "reference": "c6121466d107952821d35bec364983a88fbddab5",
                 "shasum": ""
             },
             "default-branch": true,
@@ -109,7 +109,7 @@
                 "issues": "https://github.com/Codeinwp/elementor-extra-widgets/issues",
                 "source": "https://github.com/Codeinwp/elementor-extra-widgets/tree/master"
             },
-            "time": "2021-08-02T12:23:30+00:00"
+            "time": "2021-12-22T11:09:33+00:00"
         },
         {
             "name": "codeinwp/full-width-page-templates",
@@ -292,16 +292,16 @@
         },
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.2.21",
+            "version": "3.2.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "cafd016b61ec0928c0234e312046782a77c14318"
+                "reference": "394d0f27e17dab350efa7e91bffff31f4b451fec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/cafd016b61ec0928c0234e312046782a77c14318",
-                "reference": "cafd016b61ec0928c0234e312046782a77c14318",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/394d0f27e17dab350efa7e91bffff31f4b451fec",
+                "reference": "394d0f27e17dab350efa7e91bffff31f4b451fec",
                 "shasum": ""
             },
             "require-dev": {
@@ -326,9 +326,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.21"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.22"
             },
-            "time": "2021-06-30T10:55:18+00:00"
+            "time": "2021-10-27T10:27:45+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -1350,5 +1350,5 @@
     "platform-overrides": {
         "php": "5.6"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -153,16 +153,16 @@
         },
         {
             "name": "codeinwp/gutenberg-blocks",
-            "version": "1.6.9",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/gutenberg-blocks.git",
-                "reference": "c58fc700fe616d8b4f6029c109a869257d6daeed"
+                "reference": "0f71c8754ae6585171a3013dea7131b2fbfec0c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/gutenberg-blocks/zipball/c58fc700fe616d8b4f6029c109a869257d6daeed",
-                "reference": "c58fc700fe616d8b4f6029c109a869257d6daeed",
+                "url": "https://api.github.com/repos/Codeinwp/gutenberg-blocks/zipball/0f71c8754ae6585171a3013dea7131b2fbfec0c7",
+                "reference": "0f71c8754ae6585171a3013dea7131b2fbfec0c7",
                 "shasum": ""
             },
             "require": {
@@ -196,9 +196,10 @@
             "homepage": "https://github.com/Codeinwp/gutenberg-blocks",
             "support": {
                 "issues": "https://github.com/Codeinwp/gutenberg-blocks/issues",
-                "source": "https://github.com/Codeinwp/gutenberg-blocks/tree/v1.6.9"
+                "source": "https://github.com/Codeinwp/gutenberg-blocks/tree/v1.7.0"
             },
-            "time": "2021-07-02T20:24:47+00:00"
+            "abandoned": true,
+            "time": "2021-10-10T20:03:48+00:00"
         },
         {
             "name": "codeinwp/templates-directory",
@@ -292,16 +293,16 @@
         },
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.2.21",
+            "version": "3.2.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "cafd016b61ec0928c0234e312046782a77c14318"
+                "reference": "394d0f27e17dab350efa7e91bffff31f4b451fec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/cafd016b61ec0928c0234e312046782a77c14318",
-                "reference": "cafd016b61ec0928c0234e312046782a77c14318",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/394d0f27e17dab350efa7e91bffff31f4b451fec",
+                "reference": "394d0f27e17dab350efa7e91bffff31f4b451fec",
                 "shasum": ""
             },
             "require-dev": {
@@ -326,22 +327,22 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.21"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.22"
             },
-            "time": "2021-06-30T10:55:18+00:00"
+            "time": "2021-10-27T10:27:45+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.8.2",
+            "version": "1.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "dc960a912984efb74d0a90222870c72c87f10c91"
+                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dc960a912984efb74d0a90222870c72c87f10c91",
-                "reference": "dc960a912984efb74d0a90222870c72c87f10c91",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
+                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
                 "shasum": ""
             },
             "require": {
@@ -379,12 +380,33 @@
             ],
             "authors": [
                 {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
                 },
                 {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
                     "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
                     "homepage": "https://github.com/Tobion"
                 }
             ],
@@ -401,9 +423,23 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/1.8.2"
+                "source": "https://github.com/guzzle/psr7/tree/1.8.3"
             },
-            "time": "2021-04-26T09:17:50+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-05T13:56:00+00:00"
         },
         {
             "name": "mailerlite/mailerlite-api-v2-php-sdk",
@@ -1237,16 +1273,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.0",
+            "version": "3.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
                 "shasum": ""
             },
             "require": {
@@ -1289,7 +1325,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-04-09T00:54:41+00:00"
+            "time": "2021-12-12T21:44:58+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -78,12 +78,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/elementor-extra-widgets.git",
-                "reference": "d3122da70b1e4cc75550ca5a3a6da9f619631f76"
+                "reference": "2894a02bd940b42038f0e097754498a1169b15b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/elementor-extra-widgets/zipball/d3122da70b1e4cc75550ca5a3a6da9f619631f76",
-                "reference": "d3122da70b1e4cc75550ca5a3a6da9f619631f76",
+                "url": "https://api.github.com/repos/Codeinwp/elementor-extra-widgets/zipball/2894a02bd940b42038f0e097754498a1169b15b1",
+                "reference": "2894a02bd940b42038f0e097754498a1169b15b1",
                 "shasum": ""
             },
             "default-branch": true,
@@ -109,7 +109,7 @@
                 "issues": "https://github.com/Codeinwp/elementor-extra-widgets/issues",
                 "source": "https://github.com/Codeinwp/elementor-extra-widgets/tree/master"
             },
-            "time": "2021-12-21T19:16:26+00:00"
+            "time": "2021-08-02T12:23:30+00:00"
         },
         {
             "name": "codeinwp/full-width-page-templates",
@@ -153,16 +153,16 @@
         },
         {
             "name": "codeinwp/gutenberg-blocks",
-            "version": "1.7.0",
+            "version": "1.6.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/gutenberg-blocks.git",
-                "reference": "0f71c8754ae6585171a3013dea7131b2fbfec0c7"
+                "reference": "c58fc700fe616d8b4f6029c109a869257d6daeed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/gutenberg-blocks/zipball/0f71c8754ae6585171a3013dea7131b2fbfec0c7",
-                "reference": "0f71c8754ae6585171a3013dea7131b2fbfec0c7",
+                "url": "https://api.github.com/repos/Codeinwp/gutenberg-blocks/zipball/c58fc700fe616d8b4f6029c109a869257d6daeed",
+                "reference": "c58fc700fe616d8b4f6029c109a869257d6daeed",
                 "shasum": ""
             },
             "require": {
@@ -196,10 +196,9 @@
             "homepage": "https://github.com/Codeinwp/gutenberg-blocks",
             "support": {
                 "issues": "https://github.com/Codeinwp/gutenberg-blocks/issues",
-                "source": "https://github.com/Codeinwp/gutenberg-blocks/tree/v1.7.0"
+                "source": "https://github.com/Codeinwp/gutenberg-blocks/tree/v1.6.9"
             },
-            "abandoned": true,
-            "time": "2021-10-10T20:03:48+00:00"
+            "time": "2021-07-02T20:24:47+00:00"
         },
         {
             "name": "codeinwp/templates-directory",
@@ -293,16 +292,16 @@
         },
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.2.22",
+            "version": "3.2.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "394d0f27e17dab350efa7e91bffff31f4b451fec"
+                "reference": "cafd016b61ec0928c0234e312046782a77c14318"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/394d0f27e17dab350efa7e91bffff31f4b451fec",
-                "reference": "394d0f27e17dab350efa7e91bffff31f4b451fec",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/cafd016b61ec0928c0234e312046782a77c14318",
+                "reference": "cafd016b61ec0928c0234e312046782a77c14318",
                 "shasum": ""
             },
             "require-dev": {
@@ -327,22 +326,22 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.22"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.21"
             },
-            "time": "2021-10-27T10:27:45+00:00"
+            "time": "2021-06-30T10:55:18+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.8.3",
+            "version": "1.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85"
+                "reference": "dc960a912984efb74d0a90222870c72c87f10c91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
-                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dc960a912984efb74d0a90222870c72c87f10c91",
+                "reference": "dc960a912984efb74d0a90222870c72c87f10c91",
                 "shasum": ""
             },
             "require": {
@@ -380,33 +379,12 @@
             ],
             "authors": [
                 {
-                    "name": "Graham Campbell",
-                    "email": "hello@gjcampbell.co.uk",
-                    "homepage": "https://github.com/GrahamCampbell"
-                },
-                {
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
                 },
                 {
-                    "name": "George Mponos",
-                    "email": "gmponos@gmail.com",
-                    "homepage": "https://github.com/gmponos"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/Nyholm"
-                },
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com",
-                    "homepage": "https://github.com/sagikazarmark"
-                },
-                {
                     "name": "Tobias Schultze",
-                    "email": "webmaster@tubo-world.de",
                     "homepage": "https://github.com/Tobion"
                 }
             ],
@@ -423,23 +401,9 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/1.8.3"
+                "source": "https://github.com/guzzle/psr7/tree/1.8.2"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/GrahamCampbell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/Nyholm",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-10-05T13:56:00+00:00"
+            "time": "2021-04-26T09:17:50+00:00"
         },
         {
             "name": "mailerlite/mailerlite-api-v2-php-sdk",
@@ -1273,16 +1237,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.2",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
@@ -1325,7 +1289,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-12-12T21:44:58+00:00"
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -1386,5 +1350,5 @@
     "platform-overrides": {
         "php": "5.6"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -78,12 +78,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/elementor-extra-widgets.git",
-                "reference": "2894a02bd940b42038f0e097754498a1169b15b1"
+                "reference": "d3122da70b1e4cc75550ca5a3a6da9f619631f76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/elementor-extra-widgets/zipball/2894a02bd940b42038f0e097754498a1169b15b1",
-                "reference": "2894a02bd940b42038f0e097754498a1169b15b1",
+                "url": "https://api.github.com/repos/Codeinwp/elementor-extra-widgets/zipball/d3122da70b1e4cc75550ca5a3a6da9f619631f76",
+                "reference": "d3122da70b1e4cc75550ca5a3a6da9f619631f76",
                 "shasum": ""
             },
             "default-branch": true,
@@ -109,7 +109,7 @@
                 "issues": "https://github.com/Codeinwp/elementor-extra-widgets/issues",
                 "source": "https://github.com/Codeinwp/elementor-extra-widgets/tree/master"
             },
-            "time": "2021-08-02T12:23:30+00:00"
+            "time": "2021-12-21T19:16:26+00:00"
         },
         {
             "name": "codeinwp/full-width-page-templates",
@@ -153,16 +153,16 @@
         },
         {
             "name": "codeinwp/gutenberg-blocks",
-            "version": "1.6.9",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/gutenberg-blocks.git",
-                "reference": "c58fc700fe616d8b4f6029c109a869257d6daeed"
+                "reference": "0f71c8754ae6585171a3013dea7131b2fbfec0c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/gutenberg-blocks/zipball/c58fc700fe616d8b4f6029c109a869257d6daeed",
-                "reference": "c58fc700fe616d8b4f6029c109a869257d6daeed",
+                "url": "https://api.github.com/repos/Codeinwp/gutenberg-blocks/zipball/0f71c8754ae6585171a3013dea7131b2fbfec0c7",
+                "reference": "0f71c8754ae6585171a3013dea7131b2fbfec0c7",
                 "shasum": ""
             },
             "require": {
@@ -196,9 +196,10 @@
             "homepage": "https://github.com/Codeinwp/gutenberg-blocks",
             "support": {
                 "issues": "https://github.com/Codeinwp/gutenberg-blocks/issues",
-                "source": "https://github.com/Codeinwp/gutenberg-blocks/tree/v1.6.9"
+                "source": "https://github.com/Codeinwp/gutenberg-blocks/tree/v1.7.0"
             },
-            "time": "2021-07-02T20:24:47+00:00"
+            "abandoned": true,
+            "time": "2021-10-10T20:03:48+00:00"
         },
         {
             "name": "codeinwp/templates-directory",
@@ -292,16 +293,16 @@
         },
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.2.21",
+            "version": "3.2.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "cafd016b61ec0928c0234e312046782a77c14318"
+                "reference": "394d0f27e17dab350efa7e91bffff31f4b451fec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/cafd016b61ec0928c0234e312046782a77c14318",
-                "reference": "cafd016b61ec0928c0234e312046782a77c14318",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/394d0f27e17dab350efa7e91bffff31f4b451fec",
+                "reference": "394d0f27e17dab350efa7e91bffff31f4b451fec",
                 "shasum": ""
             },
             "require-dev": {
@@ -326,22 +327,22 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.21"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.22"
             },
-            "time": "2021-06-30T10:55:18+00:00"
+            "time": "2021-10-27T10:27:45+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.8.2",
+            "version": "1.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "dc960a912984efb74d0a90222870c72c87f10c91"
+                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dc960a912984efb74d0a90222870c72c87f10c91",
-                "reference": "dc960a912984efb74d0a90222870c72c87f10c91",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
+                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
                 "shasum": ""
             },
             "require": {
@@ -379,12 +380,33 @@
             ],
             "authors": [
                 {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
                 },
                 {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
                     "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
                     "homepage": "https://github.com/Tobion"
                 }
             ],
@@ -401,9 +423,23 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/1.8.2"
+                "source": "https://github.com/guzzle/psr7/tree/1.8.3"
             },
-            "time": "2021-04-26T09:17:50+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-05T13:56:00+00:00"
         },
         {
             "name": "mailerlite/mailerlite-api-v2-php-sdk",
@@ -1237,16 +1273,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.0",
+            "version": "3.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
                 "shasum": ""
             },
             "require": {
@@ -1289,7 +1325,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-04-09T00:54:41+00:00"
+            "time": "2021-12-12T21:44:58+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -1350,5 +1386,5 @@
     "platform-overrides": {
         "php": "5.6"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -78,12 +78,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/elementor-extra-widgets.git",
-                "reference": "d3122da70b1e4cc75550ca5a3a6da9f619631f76"
+                "reference": "c6121466d107952821d35bec364983a88fbddab5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/elementor-extra-widgets/zipball/d3122da70b1e4cc75550ca5a3a6da9f619631f76",
-                "reference": "d3122da70b1e4cc75550ca5a3a6da9f619631f76",
+                "url": "https://api.github.com/repos/Codeinwp/elementor-extra-widgets/zipball/c6121466d107952821d35bec364983a88fbddab5",
+                "reference": "c6121466d107952821d35bec364983a88fbddab5",
                 "shasum": ""
             },
             "default-branch": true,
@@ -109,7 +109,7 @@
                 "issues": "https://github.com/Codeinwp/elementor-extra-widgets/issues",
                 "source": "https://github.com/Codeinwp/elementor-extra-widgets/tree/master"
             },
-            "time": "2021-12-21T19:16:26+00:00"
+            "time": "2021-12-22T11:09:33+00:00"
         },
         {
             "name": "codeinwp/full-width-page-templates",

--- a/obfx_modules/elementor-widgets/init.php
+++ b/obfx_modules/elementor-widgets/init.php
@@ -81,9 +81,9 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		return true;
 	}
 
-    private function should_add_placeholders() {
-        return wp_get_theme()->get( 'Name' ) === 'Neve' && ! self::has_valid_addons();
-    }
+	private function should_add_placeholders() {
+		return wp_get_theme()->get( 'Name' ) === 'Neve' && ! self::has_valid_addons();
+	}
 
 	/**
 	 * Method to define hooks needed.

--- a/obfx_modules/elementor-widgets/init.php
+++ b/obfx_modules/elementor-widgets/init.php
@@ -59,7 +59,7 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 *
 	 * @return bool
 	 */
-	public static function has_valid_addons() {
+	private static function has_valid_addons() {
 		if ( ! defined( 'NEVE_PRO_BASEFILE' ) ) {
 			return false;
 		}
@@ -88,7 +88,7 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 *
 	 * @return bool
 	 */
-	private function should_add_placeholders() {
+	public static function should_add_placeholders() {
 		return wp_get_theme()->get( 'Name' ) === 'Neve' && ! self::has_valid_addons();
 	}
 
@@ -104,7 +104,7 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		$this->loader->add_action( 'plugins_loaded', $this, 'load_elementor_extra_widgets' );
 		$this->loader->add_filter( 'elementor/editor/localize_settings', $this, 'localization_filter', PHP_INT_MAX );
 		$this->loader->add_action( 'elementor/editor/before_enqueue_scripts', $this, 'load_fa_styles' );
-		if ( $this->should_add_placeholders() ) {
+		if ( self::should_add_placeholders() ) {
 			$this->loader->add_action( 'elementor/editor/after_enqueue_scripts', $this, 'enqueue_editor_scripts' );
 			$this->loader->add_action( 'elementor/editor/after_enqueue_styles', $this, 'enqueue_editor_styles' );
 		}

--- a/obfx_modules/elementor-widgets/init.php
+++ b/obfx_modules/elementor-widgets/init.php
@@ -55,6 +55,8 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	public function load() {}
 
 	/**
+	 * Check for current license.
+	 *
 	 * @return bool
 	 */
 	public static function has_valid_addons() {
@@ -81,6 +83,11 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		return true;
 	}
 
+	/**
+	 * Decide if placeholders are needed.
+	 *
+	 * @return bool
+	 */
 	private function should_add_placeholders() {
 		return wp_get_theme()->get( 'Name' ) === 'Neve' && ! self::has_valid_addons();
 	}

--- a/obfx_modules/elementor-widgets/init.php
+++ b/obfx_modules/elementor-widgets/init.php
@@ -59,7 +59,7 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 *
 	 * @return bool
 	 */
-	static function should_add_placeholders() {
+	private function should_add_placeholders() {
 		return wp_get_theme()->get( 'Name' ) === 'Neve' && ! is_plugin_active( 'neve-pro-addon/neve-pro-addon.php' );
 	}
 
@@ -75,7 +75,7 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		$this->loader->add_action( 'plugins_loaded', $this, 'load_elementor_extra_widgets' );
 		$this->loader->add_filter( 'elementor/editor/localize_settings', $this, 'localization_filter', PHP_INT_MAX );
 		$this->loader->add_action( 'elementor/editor/before_enqueue_scripts', $this, 'load_fa_styles' );
-		if ( self::should_add_placeholders() ) {
+		if ( $this->should_add_placeholders() ) {
 			$this->loader->add_action( 'elementor/editor/after_enqueue_scripts', $this, 'enqueue_editor_scripts' );
 			$this->loader->add_action( 'elementor/editor/after_enqueue_styles', $this, 'enqueue_editor_styles' );
 		}
@@ -150,19 +150,18 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	public function enqueue_editor_scripts() {
 		wp_add_inline_script(
 			'elementor-editor',
-			'
-            elementor.on(\'preview:loaded\', function() {
+			'           
+            $e.routes.on(\'run\', function(){
                 setTimeout(
-                  function() 
-                  {
-                     jQuery( \'#elementor-panel-category-obfx-elementor-widgets-pro .elementor-element-wrapper\' ).on( \'click mousedown drop\', function(e) {
-                        e.preventDefault();
-                     } );
-                     
-                      jQuery( \'#elementor-panel-category-obfx-elementor-widgets-pro .elementor-element-wrapper\' ).on( \'click\', function(e) {
-                        window.open( \'https://themeisle.com/themes/neve/upgrade/?utm_medium=elementoreditor&utm_source=elementorwidget&utm_campaign=orbitfox\',\'_blank\');
-                      })
-                  }, 1000
+                    function() {
+                        jQuery( \'#elementor-panel-category-obfx-elementor-widgets-pro .elementor-element-wrapper\' ).on( \'click mousedown drop\', function(e) {
+                            e.preventDefault();
+                        });
+                        
+                        jQuery( \'#elementor-panel-category-obfx-elementor-widgets-pro .elementor-element-wrapper\' ).on( \'click drop\', function(e) {
+                            window.open( \'https://themeisle.com/themes/neve/upgrade/?utm_medium=elementoreditor&utm_source=elementorwidget&utm_campaign=orbitfox\',\'_blank\');
+                        });
+                    }, 1000
                 );
             });
         ' 

--- a/obfx_modules/elementor-widgets/init.php
+++ b/obfx_modules/elementor-widgets/init.php
@@ -55,13 +55,35 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	public function load() {}
 
 	/**
-	 * Decide if placeholders are needed.
-	 *
 	 * @return bool
 	 */
-	private function should_add_placeholders() {
-		return wp_get_theme()->get( 'Name' ) === 'Neve' && ! is_plugin_active( 'neve-pro-addon/neve-pro-addon.php' );
+	public static function has_valid_addons() {
+		if ( ! defined( 'NEVE_PRO_BASEFILE' ) ) {
+			return false;
+		}
+
+		$option_name = basename( dirname( NEVE_PRO_BASEFILE ) );
+		$option_name = str_replace( '-', '_', strtolower( trim( $option_name ) ) );
+		$status      = get_option( $option_name . '_license_data' );
+
+		if ( ! $status ) {
+			return false;
+		}
+
+		if ( ! isset( $status->license ) ) {
+			return false;
+		}
+
+		if ( $status->license === 'not_active' || $status->license === 'invalid' ) {
+			return false;
+		}
+
+		return true;
 	}
+
+    private function should_add_placeholders() {
+        return wp_get_theme()->get( 'Name' ) === 'Neve' && ! self::has_valid_addons();
+    }
 
 	/**
 	 * Method to define hooks needed.
@@ -113,7 +135,7 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		$config['initial_document']['panel']['elements_categories'] = $this->insert_before_element( $elements_categories, 'pro-elements', $obfx_cat );
 
 		$elements_categories = $config['initial_document']['panel']['elements_categories'];
-		if ( self::should_add_placeholders() && array_key_exists( 'obfx-elementor-widgets-pro', $elements_categories ) ) {
+		if ( $this->should_add_placeholders() && array_key_exists( 'obfx-elementor-widgets-pro', $elements_categories ) ) {
 			$placeholders_cat = [ 'obfx-elementor-widgets-pro' => $elements_categories['obfx-elementor-widgets-pro'] ];
 			unset( $elements_categories['obfx-elementor-widgets-pro'] );
 			$config['initial_document']['panel']['elements_categories'] = $this->insert_before_element( $elements_categories, 'pro-elements', $placeholders_cat );


### PR DESCRIPTION
Testing instructions:
- Enable Pagebuilder module for elementor in obfx dashboard.
- The widget placeholders appear only if the page builder module from obfx dashboard is active, Neve theme is active and Neve Pro is not.
- If the condition above is met, try to edit a page with elementor
- In their editor, you should see neve pro blocked widgets
- If Neve pro is enabled, the widgets should not be there

More details here: https://github.com/Codeinwp/neve-pro-addon/issues/1738