### PR TITLE
fix: solve accessibility issue on social links

### DIFF
--- a/obfx_modules/social-sharing/views/hestia-social-sharing-tpl.php
+++ b/obfx_modules/social-sharing/views/hestia-social-sharing-tpl.php
@@ -35,7 +35,7 @@ if ( ! empty( $social_links_array ) ) { ?>
 				}
 				?>
 					<li class="<?php echo esc_attr( $class ); ?>">
-						<a rel="tooltip" data-original-title="<?php echo esc_attr( __( 'Share on ', 'themeisle-companion' ) . $network_data['nicename'] ); ?>" class = "btn btn-just-icon btn-round btn-<?php echo esc_attr( $network_data['icon'] ); ?>" 
+						<a rel="tooltip" aria-label="<?php echo esc_html( $network_data['nicename'] ); ?>" data-original-title="<?php echo esc_attr( __( 'Share on ', 'themeisle-companion' ) . $network_data['nicename'] ); ?>" class = "btn btn-just-icon btn-round btn-<?php echo esc_attr( $network_data['icon'] ); ?>"
 																		 <?php
 						// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 																			echo ( isset( $network_data['target'] ) && $network_data['target'] != '0' ) ? 'target="_blank"' : '';

--- a/obfx_modules/social-sharing/views/social-sharing-tpl.php
+++ b/obfx_modules/social-sharing/views/social-sharing-tpl.php
@@ -37,6 +37,7 @@ if ( ! empty( $social_links_array ) ) { ?>
 			?>
 			<li class="<?php echo esc_attr( $class ); ?>">
 				<a class = "<?php echo esc_attr( $network_data['icon'] ); ?>"
+                    aria-label="<?php echo esc_html( $network_data['nicename'] ); ?>"
 					<?php
 					// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 					echo ( isset( $network_data['target'] ) && $network_data['target'] != '0' ) ? 'target="_blank"' : '';

--- a/obfx_modules/social-sharing/views/social-sharing-tpl.php
+++ b/obfx_modules/social-sharing/views/social-sharing-tpl.php
@@ -37,7 +37,7 @@ if ( ! empty( $social_links_array ) ) { ?>
 			?>
 			<li class="<?php echo esc_attr( $class ); ?>">
 				<a class = "<?php echo esc_attr( $network_data['icon'] ); ?>"
-                    aria-label="<?php echo esc_html( $network_data['nicename'] ); ?>"
+					aria-label="<?php echo esc_html( $network_data['nicename'] ); ?>"
 					<?php
 					// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 					echo ( isset( $network_data['target'] ) && $network_data['target'] != '0' ) ? 'target="_blank"' : '';


### PR DESCRIPTION
### Summar
Added `aria-label` on templates for social sharing links.
This should solve the accessibility issue reported by Lighthouse.

### Will affect visual aspect of the product
NO

### Test instructions
1. Activate the social sharing module
2. Check with Chrome Lighthouse that "Links do not have a discernible name" issue is not reported anymore.

<!-- Issues that this pull request closes. -->
Closes: #736.