### PR TITLE
fix: php 8 deprecation warning from uksort function

### DIFF
--- a/core/app/class-orbit-fox-admin.php
+++ b/core/app/class-orbit-fox-admin.php
@@ -457,7 +457,7 @@ class Orbit_Fox_Admin {
 		uksort(
 			$data,
 			function() {
-				return rand() > rand();
+				return rand() <=> rand();
 			}
 		);
 

--- a/core/app/class-orbit-fox-admin.php
+++ b/core/app/class-orbit-fox-admin.php
@@ -454,12 +454,8 @@ class Orbit_Fox_Admin {
 		foreach ( $th_plugins as $plugin_slug => $plugin_data ) {
 			$data[ $plugin_slug ] = $plugin_data;
 		}
-		uksort(
-			$data,
-			function() {
-				return rand() <=> rand();
-			}
-		);
+
+		shuffle( $data );
 
 		return $data;
 	}


### PR DESCRIPTION
Fixed PHP 8 warning on orbit fox dashboard

Closes https://github.com/Codeinwp/themeisle-companion/issues/735