### PR TITLE
Fix missing desktop position option

### DIFF
--- a/dashboard/src/components/ModuleSettings.js
+++ b/dashboard/src/components/ModuleSettings.js
@@ -64,7 +64,6 @@ const ModuleSettings = ({ slug }) => {
 
 	const getContent = () => {
 		const content = [];
-
 		for (let i = 0; i < options[slug].length; i++) {
 			let element = options[slug][i];
 			if (element.title && element.label) {
@@ -102,6 +101,7 @@ const ModuleSettings = ({ slug }) => {
 					element = options[slug][++i];
 				}
 				content.push(<div className="checkboxes-row"> {row} </div>);
+				i--;
 				continue;
 			}
 


### PR DESCRIPTION
- The rendering of module options was skipping items after a checkbox control type
- To test, enable obfx sharing icons module and check if desktop position option is there

Closes #717