### PR TITLE
fix: remove clients bar srcset

### DIFF
--- a/obfx_modules/companion-legacy/inc/hestia/inc/sections/hestia-clients-bar-section.php
+++ b/obfx_modules/companion-legacy/inc/hestia/inc/sections/hestia-clients-bar-section.php
@@ -66,10 +66,8 @@ if ( ! function_exists( 'hestia_clients_bar' ) ) :
 
 							$image_id = function_exists( 'attachment_url_to_postid' ) ? attachment_url_to_postid( preg_replace( '/-\d{1,4}x\d{1,4}/i', '', $image ) ) : '';
 							$alt_text = '';
-                            $srcset   = '';
 							if ( ! empty( $image_id ) ) {
 								$alt_text = 'alt="' . get_post_meta( $image_id, '_wp_attachment_image_alt', true ) . '"';
-                                $srcset = 'srcset="' . wp_get_attachment_image_srcset( $image_id, 'full' ) . '"';
 							}
 
 							if ( ! empty( $image ) ) {
@@ -82,7 +80,7 @@ if ( ! function_exists( 'hestia_clients_bar' ) ) :
 									$link_html .= '>';
 									echo wp_kses_post( $link_html );
 								}
-                                echo '<img src="' . esc_url( $image ) . '" ' . wp_kses_post( $alt_text ) . ' ' . wp_kses_post( $srcset ) . '>';
+                                echo '<img src="' . esc_url( $image ) . '" ' . wp_kses_post( $alt_text ) . '>';
 								if ( ! empty( $link ) ) {
 									echo '</a>';
 								}


### PR DESCRIPTION
Clients bar loads images as they are without adding a width restriction in CSS. Adding srcset parameter will produce the issue described in #754.

This PR removes the srcset on those images.

To test, please use Hestia (Free) + This PR.
Please also test https://github.com/Codeinwp/hestia-pro/pull/2445