### PR TITLE
fix: php8.2 Dynamic Properties are deprecated

### DIFF
--- a/obfx_modules/mystock-import/init.php
+++ b/obfx_modules/mystock-import/init.php
@@ -37,6 +37,13 @@ class Mystock_Import_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 */
 	const CACHE_DAYS = 7;
 
+	/**
+	 * Media strings ( used when the gutenberg editor is disabled ).
+	 *
+	 * @var string
+	 */
+	private $strings = [];
+
 
 	/**
 	 * Mystock_Import_OBFX_Module constructor.

--- a/obfx_modules/mystock-import/init.php
+++ b/obfx_modules/mystock-import/init.php
@@ -42,7 +42,7 @@ class Mystock_Import_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 *
 	 * @var string
 	 */
-	private $strings = [];
+	private $strings = array();
 
 
 	/**


### PR DESCRIPTION
- Added the class property as Dynamic Properties are deprecated. See more about this [here](https://php.watch/versions/8.2/dynamic-properties-deprecated)

### Testing instructions
-Enable wp_debug
- Install Orbit Fox and activate the MyStock Import module
- Check that the deprecated message in the dashboard is not there anymore

Closes: #792
