### PR TITLE
fix: solve vulnerability with script metadata #816

### DIFF
--- a/obfx_modules/header-footer-scripts/init.php
+++ b/obfx_modules/header-footer-scripts/init.php
@@ -86,6 +86,56 @@ class Header_Footer_Scripts_OBFX_Module extends Orbit_Fox_Module_Abstract {
 
 		$this->loader->add_action( 'wp_head', $this, 'do_header_scripts' );
 		$this->loader->add_action( 'wp_footer', $this, 'do_footer_scripts' );
+
+		/**
+		 * Since we allow for the script meta to be unfiltered, we need to make sure that
+		 * the current user is allowed to add unfiltered html. If not we prevent the meta from being saved or listed.
+		 */
+		$this->loader->add_filter( 'add_post_metadata', $this, 'check_post_metadata', 10, 5 );
+		$this->loader->add_filter( 'update_post_metadata', $this, 'check_post_metadata', 10, 5 );
+		$this->loader->add_filter( 'is_protected_meta', $this, 'is_meta_protected', 10, 3 );
+	}
+
+	/**
+	 * Check if meta is protected.
+	 *
+	 * @param bool $protected Whether the key is considered protected.
+	 * @param string $meta_key Metadata key.
+	 * @param string $meta_type Type of object metadata is for. Accepts 'post', 'comment', 'term', 'user', or any other object type with an associated meta table.
+	 *
+	 * @return bool
+	 */
+	final public function is_meta_protected( $protected, $meta_key, $meta_type ) {
+		if ( ! in_array( $meta_key, array( 'obfx-header-scripts', 'obfx-footer-scripts' ), true ) ) {
+			return $protected;
+		}
+
+		if ( current_user_can( 'unfiltered_html' ) ) {
+			return $protected;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param null | bool $check Whether the meta key is allowed for update or add actions.
+	 * @param int $object_id Object ID.
+	 * @param string $meta_key Metadata key.
+	 * @param mixed $meta_value Metadata value.
+	 * @param mixed $prev_value Previous value of metadata.
+	 *
+	 * @return false
+	 */
+	final public function check_post_metadata( $check, $object_id, $meta_key, $meta_value, $prev_value ) {
+		if ( ! in_array( $meta_key, array( 'obfx-header-scripts', 'obfx-footer-scripts' ), true ) ) {
+			return $check;
+		}
+
+		if ( current_user_can( 'unfiltered_html' ) ) {
+			return $check;
+		}
+
+		return false;
 	}
 
 	/**

--- a/obfx_modules/header-footer-scripts/init.php
+++ b/obfx_modules/header-footer-scripts/init.php
@@ -124,7 +124,7 @@ class Header_Footer_Scripts_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 * @param mixed $meta_value Metadata value.
 	 * @param mixed $prev_value Previous value of metadata.
 	 *
-	 * @return false
+	 * @return null | bool
 	 */
 	final public function check_post_metadata( $check, $object_id, $meta_key, $meta_value, $prev_value ) {
 		if ( ! in_array( $meta_key, array( 'obfx-header-scripts', 'obfx-footer-scripts' ), true ) ) {


### PR DESCRIPTION
### Summary

Fixes a vulnerability with using the custom fields to save data to the header/footer script boxes when the user does not have the capability to save `unfiltered_html`.

### Screenshots
<details>
    <summary>Post Preferences (pic. 1)</summary>

![image](https://github.com/Codeinwp/themeisle-companion/assets/23024731/01a0e185-fce9-4914-8341-07450916b7cb)
</details>

<details>
    <summary>Post Preferences (pic. 2)</summary>

![image](https://github.com/Codeinwp/themeisle-companion/assets/23024731/c571fa23-5231-4908-bbf0-da7d87b75b48)
</details>

<details>
    <summary>New custom fields name options (pic. 3)</summary>

![image](https://github.com/Codeinwp/themeisle-companion/assets/23024731/b7a1bbec-2844-4045-aab8-f931aaee7d78)
</details>

### How to test
1. On a fresh instance with Orbit Fox
2. Create a new user account with the `Contributor` role
3. Login as a `Contributor`
4. Create a new Post
5. Enable **Custom Fields**  from the **Post Preferences** (see pic. 1 and pic. 2)
6. Check that `obfx-header-scripts` and `obfx-footer-scripts` is not listed under the **Add new custom field** name.
7. Use the steps detailed here for further testing: https://github.com/Codeinwp/themeisle/issues/1612

References: Codeinwp/themeisle#1612
Closes: #816 