### PR TITLE
Fixed cross-site scripting via svg file upload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "codeinwp/full-width-page-templates": "master",
     "codeinwp/themeisle-sdk": "^3.3",
     "codeinwp/elementor-extra-widgets": "dev-master",
-    "codeinwp/themeisle-content-forms": "dev-master"
+    "codeinwp/themeisle-content-forms": "dev-master",
+    "enshrined/svg-sanitize": "^0.19.0"
   },
   "autoload": {
     "files": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "651ea6d52749a4a303b5eabe46a4a27f",
+    "content-hash": "98526a13b8c1cb51fd026cef17ddbaae",
     "packages": [
         {
             "name": "codeinwp/elementor-extra-widgets",
@@ -163,6 +163,51 @@
                 "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.20"
             },
             "time": "2024-04-16T12:27:32+00:00"
+        },
+        {
+            "name": "enshrined/svg-sanitize",
+            "version": "0.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/darylldoyle/svg-sanitizer.git",
+                "reference": "e95cd17be68e45f523cbfb0fe50cdd891b0cf20e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/e95cd17be68e45f523cbfb0fe50cdd891b0cf20e",
+                "reference": "e95cd17be68e45f523cbfb0fe50cdd891b0cf20e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": "^5.6 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^8.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "enshrined\\svgSanitize\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Daryll Doyle",
+                    "email": "daryll@enshrined.co.uk"
+                }
+            ],
+            "description": "An SVG sanitizer for PHP",
+            "support": {
+                "issues": "https://github.com/darylldoyle/svg-sanitizer/issues",
+                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.19.0"
+            },
+            "time": "2024-06-18T10:27:15+00:00"
         }
     ],
     "packages-dev": [
@@ -558,5 +603,5 @@
     "platform-overrides": {
         "php": "5.6"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/obfx_modules/custom-fonts/custom_fonts_admin.php
+++ b/obfx_modules/custom-fonts/custom_fonts_admin.php
@@ -405,44 +405,101 @@ class Custom_Fonts_Admin {
 	}
 
 	/**
-	 * Filter data for the current file to upload.
+	 * Check if the file is an SVG, if so handle appropriately
 	 *
-	 * @param array $file SVG file.
+	 * @param array $file An array of data for a single file.
 	 *
-	 * @return array
+	 * @return mixed
 	 */
-	public function sanitize_svg_upload( $file ) {
+	public function check_svg_and_sanitize( $file ) {
+		// Ensure we have a proper file path before processing.
+		if ( ! isset( $file['tmp_name'] ) ) {
+			return $file;
+		}
+
+		$file_name   = isset( $file['name'] ) ? $file['name'] : '';
+		$wp_filetype = wp_check_filetype_and_ext( $file['tmp_name'], $file_name );
+		$type        = ! empty( $wp_filetype['type'] ) ? $wp_filetype['type'] : '';
+
+		if ( 'image/svg+xml' === $type ) {
+			if ( ! current_user_can( 'upload_files' ) ) {
+				$file['error'] = 'Invalid';
+				return $file;
+			}
+
+			if ( ! $this->sanitize_svg( $file['tmp_name'] ) ) {
+				$file['error'] = 'Invalid';
+			}
+		}
+
+		return $file;
+	}
+
+	/**
+	 * Sanitize the SVG
+	 *
+	 * @param string $file Temp file path.
+	 *
+	 * @return bool|int
+	 */
+	protected function sanitize_svg( $file ) {
 		if ( ! function_exists( 'WP_Filesystem' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 		}
 		WP_Filesystem();
 		global $wp_filesystem;
 
-		// Return the default file if the file name does not exist.
-		if ( ! isset( $file['name'] ) ) {
-			return $file;
-		}
-		// Get file type.
-		$filetype = wp_check_filetype( $file['name'], null );
-		// Check is svg image.
-		if ( 'image/svg+xml' === $filetype['type'] ) {
-			$contents = $wp_filesystem->get_contents( $file['tmp_name'] );
-			// Remove potentially harmful code from SVG content.
-			$contents = preg_replace(
-				array(
-					'/<script\b[^>]*>(.*?)<\/script>/is',
-					'/<!ENTITY(.*?)>/is',
-					'/<!DOCTYPE(.*?)>/is',
-				),
-				'',
-				$contents
-			);
+		$dirty = $wp_filesystem->get_contents( $file );
 
-			// Save the sanitized content back to the file.
-			$wp_filesystem->put_contents( $file['tmp_name'], $contents );
+		// Is the SVG gzipped? If so we try and decode the string.
+		$is_zipped = $this->is_gzipped( $dirty );
+		if ( $is_zipped && ( ! function_exists( 'gzdecode' ) || ! function_exists( 'gzencode' ) ) ) {
+			return false;
 		}
 
-		return $file;
+		if ( $is_zipped ) {
+			$dirty = gzdecode( $dirty );
+
+			// If decoding fails, bail as we're not secure.
+			if ( false === $dirty ) {
+				return false;
+			}
+		}
+
+		$sanitizer = new enshrined\svgSanitize\Sanitizer();
+		$clean     = $sanitizer->sanitize( $dirty );
+
+		if ( false === $clean ) {
+			return false;
+		}
+
+		// If we were gzipped, we need to re-zip.
+		if ( $is_zipped ) {
+			$clean = gzencode( $clean );
+		}
+
+		$wp_filesystem->put_contents( $file, $clean );
+
+		return true;
+	}
+
+	/**
+	 * Check if the contents are gzipped
+	 *
+	 * @see http://www.gzip.org/zlib/rfc-gzip.html#member-format
+	 *
+	 * @param string $contents Content to check.
+	 *
+	 * @return bool
+	 */
+	protected function is_gzipped( $contents ) {
+		// phpcs:disable Generic.Strings.UnnecessaryStringConcat.Found
+		if ( function_exists( 'mb_strpos' ) ) {
+			return 0 === mb_strpos( $contents, "\x1f" . "\x8b" . "\x08" );
+		} else {
+			return 0 === strpos( $contents, "\x1f" . "\x8b" . "\x08" );
+		}
+		// phpcs:enable
 	}
 
 }

--- a/obfx_modules/custom-fonts/custom_fonts_admin.php
+++ b/obfx_modules/custom-fonts/custom_fonts_admin.php
@@ -428,9 +428,15 @@ class Custom_Fonts_Admin {
 		if ( 'image/svg+xml' === $filetype['type'] ) {
 			$contents = $wp_filesystem->get_contents( $file['tmp_name'] );
 			// Remove potentially harmful code from SVG content.
-			$contents = preg_replace( '/<script\b[^>]*>(.*?)<\/script>/is', '', $contents );
-			$contents = preg_replace( '/<!ENTITY(.*?)>/is', '', $contents );
-			$contents = preg_replace( '/<!DOCTYPE(.*?)>/is', '', $contents );
+			$contents = preg_replace(
+				array(
+					'/<script\b[^>]*>(.*?)<\/script>/is',
+					'/<!ENTITY(.*?)>/is',
+					'/<!DOCTYPE(.*?)>/is',
+				),
+				'',
+				$contents
+			);
 
 			// Save the sanitized content back to the file.
 			$wp_filesystem->put_contents( $file['tmp_name'], $contents );

--- a/obfx_modules/custom-fonts/init.php
+++ b/obfx_modules/custom-fonts/init.php
@@ -73,7 +73,7 @@ class Custom_Fonts_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		$this->loader->add_action( 'create_obfx_custom_fonts', $admin_instance, 'save_metadata' );
 		$this->loader->add_filter( 'upload_mimes', $admin_instance, 'add_fonts_to_allowed_mimes' );
 		$this->loader->add_filter( 'wp_check_filetype_and_ext', $admin_instance, 'update_mime_types', 10, 3 );
-		$this->loader->add_filter( 'wp_handle_upload_prefilter', $admin_instance, 'sanitize_svg_upload', 99 );
+		$this->loader->add_filter( 'wp_handle_upload_prefilter', $admin_instance, 'sanitize_svg_upload' );
 
 		$public_instance = new Custom_Fonts_Public();
 

--- a/obfx_modules/custom-fonts/init.php
+++ b/obfx_modules/custom-fonts/init.php
@@ -73,6 +73,7 @@ class Custom_Fonts_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		$this->loader->add_action( 'create_obfx_custom_fonts', $admin_instance, 'save_metadata' );
 		$this->loader->add_filter( 'upload_mimes', $admin_instance, 'add_fonts_to_allowed_mimes' );
 		$this->loader->add_filter( 'wp_check_filetype_and_ext', $admin_instance, 'update_mime_types', 10, 3 );
+		$this->loader->add_filter( 'wp_handle_upload_prefilter', $admin_instance, 'sanitize_svg_upload', 99 );
 
 		$public_instance = new Custom_Fonts_Public();
 

--- a/obfx_modules/custom-fonts/init.php
+++ b/obfx_modules/custom-fonts/init.php
@@ -73,7 +73,7 @@ class Custom_Fonts_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		$this->loader->add_action( 'create_obfx_custom_fonts', $admin_instance, 'save_metadata' );
 		$this->loader->add_filter( 'upload_mimes', $admin_instance, 'add_fonts_to_allowed_mimes' );
 		$this->loader->add_filter( 'wp_check_filetype_and_ext', $admin_instance, 'update_mime_types', 10, 3 );
-		$this->loader->add_filter( 'wp_handle_upload_prefilter', $admin_instance, 'sanitize_svg_upload' );
+		$this->loader->add_filter( 'wp_handle_upload_prefilter', $admin_instance, 'check_svg_and_sanitize' );
 
 		$public_instance = new Custom_Fonts_Public();
 


### PR DESCRIPTION
### Summary

In this PR I've filtered the SVG image content and removed the harmful code to fix the cross-site scripting vulnerability issue.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/neve-pro-addon#2842
