### PR TITLE
Deactivate template directory module by default

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -34,7 +34,7 @@ jobs:
         run: composer run lint
   phpunit:
       name: Phpunit
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       services:
         mysql:
           image: mysql:5.7

--- a/obfx_modules/template-directory/init.php
+++ b/obfx_modules/template-directory/init.php
@@ -29,7 +29,7 @@ class Template_Directory_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		parent::__construct();
 		$this->name                  = __( 'Template Directory Module', 'themeisle-companion' );
 		$this->description           = __( 'The awesome template directory is aiming to provide a wide range of templates that you can import straight into your website.', 'themeisle-companion' );
-		$this->active_default        = true;
+		$this->active_default        = false;
 		$this->refresh_after_enabled = true;
 	}
 


### PR DESCRIPTION
### Summary
- deactivates template directory module by default
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install plugin & activate
- Template directory module should be disabled

## Check before Pull Request is ready:

* ~[ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR~
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* ~[ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)~

<!-- Issues that this pull request closes. -->
Closes Codeinwp/hestia-pro#2683.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
