### PR TITLE
Fixed load textdomain issue with WP 6.7

### DIFF
--- a/themeisle-companion.php
+++ b/themeisle-companion.php
@@ -116,4 +116,4 @@ spl_autoload_register( array( 'Autoloader', 'loader' ) );
  *
  * @since   1.0.0
  */
-run_orbit_fox();
+add_action( 'init', 'run_orbit_fox' );


### PR DESCRIPTION
### Summary
I have removed the early translation function call following [WordPress standards](https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/).

### Will affect visual aspect of the product
Yes

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/themeisle-companion/issues/871
