### PR TITLE
Fixed compatibility issues with WordPress 6.7 and Elementor widgets

### DIFF
--- a/core/app/abstract/class-orbit-fox-module-abstract.php
+++ b/core/app/abstract/class-orbit-fox-module-abstract.php
@@ -167,6 +167,7 @@ abstract class Orbit_Fox_Module_Abstract {
 	 */
 	public function register_loader( Orbit_Fox_Loader $loader ) {
 		$this->loader = $loader;
+		$this->loader->add_action( 'init', $this, 'set_module_strings' );
 		$this->loader->add_action( $this->get_slug() . '_activate', $this, 'activate' );
 		$this->loader->add_action( $this->get_slug() . '_deactivate', $this, 'deactivate' );
 	}
@@ -823,5 +824,13 @@ abstract class Orbit_Fox_Module_Abstract {
 
 		update_option( $option_name, 'no' );
 		return false;
+	}
+
+	/**
+	 * Setup module strings
+	 *
+	 * @access  public
+	 */
+	public function set_module_strings() {
 	}
 }

--- a/obfx_modules/beaver-widgets/init.php
+++ b/obfx_modules/beaver-widgets/init.php
@@ -24,9 +24,18 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 */
 	public function __construct() {
 		parent::__construct();
+
+		$this->active_default = true;
+	}
+
+	/**
+	 * Setup module strings
+	 *
+	 * @access  public
+	 */
+	public function set_module_strings() {
 		$this->name           = __( 'Page builder widgets', 'themeisle-companion' );
 		$this->description    = __( 'Adds widgets to the most popular builders: Elementor or Beaver. More to come!', 'themeisle-companion' );
-		$this->active_default = true;
 	}
 
 	/**

--- a/obfx_modules/companion-legacy/init.php
+++ b/obfx_modules/companion-legacy/init.php
@@ -29,7 +29,14 @@ class Companion_Legacy_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		parent::__construct();
 
 		$this->active_default = true;
+	}
 
+	/**
+	 * Setup module strings
+	 *
+	 * @access  public
+	 */
+	public function set_module_strings() {
 		$this->inc_dir = $this->get_dir() . DIRECTORY_SEPARATOR . 'inc' . DIRECTORY_SEPARATOR;
 		if ( ! defined( 'THEMEISLE_COMPANION_PATH' ) ) {
 			define( 'THEMEISLE_COMPANION_PATH', $this->inc_dir );
@@ -46,7 +53,6 @@ class Companion_Legacy_OBFX_Module extends Orbit_Fox_Module_Abstract {
 			require_once $this->inc_dir . 'zerif-lite' . DIRECTORY_SEPARATOR . 'widgets' . DIRECTORY_SEPARATOR . 'widget-team.php';
 			require_once $this->inc_dir . 'zerif-lite' . DIRECTORY_SEPARATOR . 'functions.php';
 		}
-
 
 		if ( $this->is_hestia() ) {
 			require_once $this->inc_dir . 'hestia' . DIRECTORY_SEPARATOR . 'functions.php';

--- a/obfx_modules/companion-legacy/init.php
+++ b/obfx_modules/companion-legacy/init.php
@@ -28,15 +28,6 @@ class Companion_Legacy_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	public function __construct() {
 		parent::__construct();
 
-		$this->active_default = true;
-	}
-
-	/**
-	 * Setup module strings
-	 *
-	 * @access  public
-	 */
-	public function set_module_strings() {
 		$this->inc_dir = $this->get_dir() . DIRECTORY_SEPARATOR . 'inc' . DIRECTORY_SEPARATOR;
 		if ( ! defined( 'THEMEISLE_COMPANION_PATH' ) ) {
 			define( 'THEMEISLE_COMPANION_PATH', $this->inc_dir );
@@ -44,9 +35,7 @@ class Companion_Legacy_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		if ( ! defined( 'THEMEISLE_COMPANION_URL' ) ) {
 			define( 'THEMEISLE_COMPANION_URL', plugin_dir_url( $this->inc_dir ) );
 		}
-		$theme_name = '';
 		if ( $this->is_zerif() ) {
-			$theme_name = 'Zerif';
 			require_once $this->inc_dir . 'zerif-lite' . DIRECTORY_SEPARATOR . 'widgets' . DIRECTORY_SEPARATOR . 'widget-focus.php';
 			require_once $this->inc_dir . 'zerif-lite' . DIRECTORY_SEPARATOR . 'widgets' . DIRECTORY_SEPARATOR . 'widget-testimonial.php';
 			require_once $this->inc_dir . 'zerif-lite' . DIRECTORY_SEPARATOR . 'widgets' . DIRECTORY_SEPARATOR . 'widget-clients.php';
@@ -57,12 +46,33 @@ class Companion_Legacy_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		if ( $this->is_hestia() ) {
 			require_once $this->inc_dir . 'hestia' . DIRECTORY_SEPARATOR . 'functions.php';
 			require_once $this->inc_dir . 'hestia' . DIRECTORY_SEPARATOR . 'common-functions.php';
-			$theme_name = 'Hestia';
 
 		}
 
 		if ( $this->is_hestia_pro() ) {
 			require_once $this->inc_dir . 'hestia' . DIRECTORY_SEPARATOR . 'common-functions.php';
+
+		}
+		$this->active_default = true;
+	}
+
+	/**
+	 * Setup module strings
+	 *
+	 * @access  public
+	 */
+	public function set_module_strings() {
+		$theme_name = '';
+		if ( $this->is_zerif() ) {
+			$theme_name = 'Zerif';
+		}
+
+		if ( $this->is_hestia() ) {
+			$theme_name = 'Hestia';
+
+		}
+
+		if ( $this->is_hestia_pro() ) {
 			$theme_name = 'Hestia Pro';
 
 		}

--- a/obfx_modules/companion-legacy/init.php
+++ b/obfx_modules/companion-legacy/init.php
@@ -300,8 +300,8 @@ class Companion_Legacy_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		}
 
 		if ( $this->is_hestia() ) {
-			$this->hestia_require();
-			$this->hestia_fix_duplicate_widgets();
+			$this->loader->add_action( 'after_setup_theme', $this, 'hestia_require' );
+			$this->loader->add_action( 'after_setup_theme', $this, 'hestia_fix_duplicate_widgets' );
 			$this->loader->add_action( 'wp_enqueue_scripts', $this, 'hestia_enqueue_clients_style' );
 			$this->loader->add_filter( 'hestia_clients_bar_default_content', $this, 'hestia_load_clients_default_content' );
 			$this->loader->add_filter( 'hestia_top_bar_alignment_default', $this, 'hestia_top_bar_default_alignment' );
@@ -310,7 +310,7 @@ class Companion_Legacy_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		}
 
 		if ( $this->is_hestia_pro() ) {
-			$this->hestia_fix_duplicate_widgets();
+			$this->loader->add_action( 'after_setup_theme', $this, 'hestia_fix_duplicate_widgets' );
 			$this->loader->add_filter( 'hestia_clients_bar_default_content', $this, 'hestia_load_clients_default_content' );
 			$this->loader->add_filter( 'hestia_top_bar_alignment_default', $this, 'hestia_top_bar_default_alignment' );
 		}

--- a/obfx_modules/custom-fonts/init.php
+++ b/obfx_modules/custom-fonts/init.php
@@ -27,10 +27,19 @@ class Custom_Fonts_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 */
 	public function __construct() {
 		parent::__construct();
-		$this->name                  = __( 'Custom fonts', 'themeisle-companion' );
-		$this->description           = __( 'Upload custom fonts and use them anywhere on your site.', 'themeisle-companion' );
+
 		$this->active_default        = false;
 		$this->refresh_after_enabled = true;
+	}
+
+	/**
+	 * Setup module strings
+	 *
+	 * @access  public
+	 */
+	public function set_module_strings() {
+		$this->name                  = __( 'Custom fonts', 'themeisle-companion' );
+		$this->description           = __( 'Upload custom fonts and use them anywhere on your site.', 'themeisle-companion' );
 	}
 
 	/**

--- a/obfx_modules/custom-fonts/init.php
+++ b/obfx_modules/custom-fonts/init.php
@@ -63,7 +63,7 @@ class Custom_Fonts_OBFX_Module extends Orbit_Fox_Module_Abstract {
 		$this->loader->add_action( 'admin_enqueue_scripts', $this, 'enqueue_media_scripts' );
 
 		$admin_instance = new Custom_Fonts_Admin();
-		$admin_instance->create_taxonomy();
+		$this->loader->add_action( 'init', $admin_instance, 'create_taxonomy' );
 		$this->loader->add_action( 'admin_menu', $admin_instance, 'add_to_menu' );
 		$this->loader->add_action( 'admin_head', $admin_instance, 'edit_custom_font_form' );
 		$this->loader->add_filter( 'manage_edit-obfx_custom_fonts_columns', $admin_instance, 'manage_columns' );

--- a/obfx_modules/elementor-widgets/init.php
+++ b/obfx_modules/elementor-widgets/init.php
@@ -29,6 +29,16 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 */
 	public function __construct() {
 		parent::__construct();
+
+		$this->active_default = true;
+	}
+
+	/**
+	 * Setup module strings
+	 *
+	 * @access  public
+	 */
+	public function set_module_strings() {
 		$this->name        = __( 'Page builder widgets', 'themeisle-companion' );
 		$this->description = __( 'Adds widgets to the most popular builders: Elementor or Beaver. More to come!', 'themeisle-companion' );
 
@@ -60,8 +70,6 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 					</a>
 				</div>';
 		}
-
-		$this->active_default = true;
 	}
 
 	/**

--- a/obfx_modules/google-analytics/init.php
+++ b/obfx_modules/google-analytics/init.php
@@ -21,13 +21,11 @@ class Google_Analytics_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	private $api_url = 'https://analytics.orbitfox.com/api/pirate-bridge/v1';
 
 	/**
-	 * Test_OBFX_Module constructor.
+	 * Setup module strings
 	 *
-	 * @since   4.0.3
 	 * @access  public
 	 */
-	public function __construct() {
-		parent::__construct();
+	public function set_module_strings() {
 		$this->name        = __( 'Analytics Integration', 'themeisle-companion' );
 		$this->description = __( 'A module to integrate Google Analytics into your site easily.', 'themeisle-companion' );
 	}

--- a/obfx_modules/header-footer-scripts/init.php
+++ b/obfx_modules/header-footer-scripts/init.php
@@ -27,10 +27,18 @@ class Header_Footer_Scripts_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 */
 	public function __construct() {
 		parent::__construct();
-		$this->name = __( 'Header Footer Scripts', 'themeisle-companion' );
 
-		$this->description    = __( 'An easy way to add scripts, such as tracking and analytics scripts, to the header and footer of your website, as well as in the body of your posts and pages.', 'themeisle-companion' );
 		$this->active_default = true;
+	}
+
+	/**
+	 * Setup module strings
+	 *
+	 * @access  public
+	 */
+	public function set_module_strings() {
+		$this->name = __( 'Header Footer Scripts', 'themeisle-companion' );
+		$this->description    = __( 'An easy way to add scripts, such as tracking and analytics scripts, to the header and footer of your website, as well as in the body of your posts and pages.', 'themeisle-companion' );
 		$this->meta_controls  = array(
 			'obfx-header-scripts' => array(
 				'type'        => 'textarea',

--- a/obfx_modules/menu-icons/init.php
+++ b/obfx_modules/menu-icons/init.php
@@ -30,11 +30,20 @@ class Menu_Icons_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 */
 	public function __construct() {
 		parent::__construct();
-		$this->name           = __( 'Menu Icons', 'themeisle-companion' );
-		$this->description    = __( 'Module to define menu icons for navigation.', 'themeisle-companion' );
+
 		$this->active_default = true;
 
 		add_action( 'admin_init', array( $this, 'check_conflict' ), 99 );
+	}
+
+	/**
+	 * Setup module strings
+	 *
+	 * @access  public
+	 */
+	public function set_module_strings() {
+		$this->name           = __( 'Menu Icons', 'themeisle-companion' );
+		$this->description    = __( 'Module to define menu icons for navigation.', 'themeisle-companion' );
 	}
 
 

--- a/obfx_modules/mystock-import/init.php
+++ b/obfx_modules/mystock-import/init.php
@@ -53,9 +53,18 @@ class Mystock_Import_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 */
 	public function __construct() {
 		parent::__construct();
+
+		$this->active_default = true;
+	}
+
+	/**
+	 * Setup module strings
+	 *
+	 * @access  public
+	 */
+	public function set_module_strings() {
 		$this->name           = __( 'Mystock Import', 'themeisle-companion' );
 		$this->description    = __( 'Module to import images directly from', 'themeisle-companion' ) . sprintf( ' <a href="%s" target="_blank">mystock.photos</a>', 'https://mystock.photos' );
-		$this->active_default = true;
 	}
 
 

--- a/obfx_modules/policy-notice/init.php
+++ b/obfx_modules/policy-notice/init.php
@@ -17,14 +17,11 @@
 class Policy_Notice_OBFX_Module extends Orbit_Fox_Module_Abstract {
 
 	/**
-	 * Test_OBFX_Module constructor.
+	 * Setup module strings
 	 *
-	 * @since   1.0.0
 	 * @access  public
 	 */
-	public function __construct() {
-		parent::__construct();
-
+	public function set_module_strings() {
 		$this->name        = __( 'Policy Notice', 'themeisle-companion' );
 		$this->description = __( 'A simple notice bar which will help you inform users about your website policy.', 'themeisle-companion' );
 	}

--- a/obfx_modules/social-sharing/init.php
+++ b/obfx_modules/social-sharing/init.php
@@ -20,13 +20,11 @@ class Social_Sharing_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	private $social_share_links = array();
 
 	/**
-	 * Social_Sharing_OBFX_Module  constructor.
+	 * Setup module strings
 	 *
-	 * @since   1.0.0
 	 * @access  public
 	 */
-	public function __construct() {
-		parent::__construct();
+	public function set_module_strings() {
 		$this->name = __( 'Social Sharing Module', 'themeisle-companion' );
 		/*
 		 * translators: %s Document anchor link.

--- a/obfx_modules/template-directory/init.php
+++ b/obfx_modules/template-directory/init.php
@@ -27,10 +27,19 @@ class Template_Directory_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 */
 	public function __construct() {
 		parent::__construct();
-		$this->name                  = __( 'Template Directory Module', 'themeisle-companion' );
-		$this->description           = __( 'The awesome template directory is aiming to provide a wide range of templates that you can import straight into your website.', 'themeisle-companion' );
+
 		$this->active_default        = false;
 		$this->refresh_after_enabled = true;
+	}
+
+	/**
+	 * Setup module strings
+	 *
+	 * @access  public
+	 */
+	public function set_module_strings() {
+		$this->name                  = __( 'Template Directory Module', 'themeisle-companion' );
+		$this->description           = __( 'The awesome template directory is aiming to provide a wide range of templates that you can import straight into your website.', 'themeisle-companion' );
 	}
 
 	/**

--- a/themeisle-companion.php
+++ b/themeisle-companion.php
@@ -111,9 +111,4 @@ Autoloader::define_namespaces( array( 'Orbit_Fox', 'OBFX', 'OBFX_Module' ) );
  */
 spl_autoload_register( array( 'Autoloader', 'loader' ) );
 
-/**
- * The start of the app.
- *
- * @since   1.0.0
- */
-add_action( 'init', 'run_orbit_fox' );
+run_orbit_fox();


### PR DESCRIPTION
### Summary
I have reverted the changes from the latest release, implemented new updates to fix the text domain loading issue in WordPress 6.7.*, and resolved the issue with the Elementor widget.

### Will affect visual aspect of the product
Yes

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/themeisle-companion/issues/878
