### PR TITLE
Fixed escaping html tags issue

### DIFF
--- a/obfx_modules/elementor-extra-widgets/widgets/elementor/pricing-table.php
+++ b/obfx_modules/elementor-extra-widgets/widgets/elementor/pricing-table.php
@@ -1039,23 +1039,25 @@ class Pricing_Table extends Widget_Base {
 			$output .= '<div class="obfx-title-wrapper">';
 			if ( ! empty( $settings['title'] ) ) {
 				// Start of title tag.
-				$output .= '<' . esc_html( $settings['title_tag'] ) . ' ' . $this->get_render_attribute_string( 'title' ) . '>';
+				$title_tag = in_array( $settings['title_tag'], array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ), true ) ? $settings['title_tag'] : 'h1';
+				$output   .= '<' . esc_html( $title_tag ) . ' ' . $this->get_render_attribute_string( 'title' ) . '>';
 
 				// Title string.
 				$output .= esc_html( $settings['title'] );
 
 				// End of title tag.
-				$output .= '</' . esc_html( $settings['title_tag'] ) . '>';
+				$output .= '</' . esc_html( $title_tag ) . '>';
 			}
 			if ( ! empty( $settings['subtitle'] ) ) {
 				// Start of subtitle tag.
-				$output .= '<' . esc_html( $settings['subtitle_tag'] ) . ' ' . $this->get_render_attribute_string( 'subtitle' ) . '>';
+				$subtitle_tag = in_array( $settings['subtitle_tag'], array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ), true ) ? $settings['subtitle_tag'] : 'h1';
+				$output      .= '<' . esc_html( $subtitle_tag ) . ' ' . $this->get_render_attribute_string( 'subtitle' ) . '>';
 
 				// Subtitle string.
 				$output .= esc_html( $settings['subtitle'] );
 
 				// End of subtitle tag.
-				$output .= '</' . esc_html( $settings['subtitle_tag'] ) . '>';
+				$output .= '</' . esc_html( $subtitle_tag ) . '>';
 
 			}
 

--- a/obfx_modules/elementor-extra-widgets/widgets/elementor/pricing-table.php
+++ b/obfx_modules/elementor-extra-widgets/widgets/elementor/pricing-table.php
@@ -1039,7 +1039,7 @@ class Pricing_Table extends Widget_Base {
 			$output .= '<div class="obfx-title-wrapper">';
 			if ( ! empty( $settings['title'] ) ) {
 				// Start of title tag.
-				$title_tag = in_array( $settings['title_tag'], array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ), true ) ? $settings['title_tag'] : 'h1';
+				$title_tag = $this->sanitize_tag( $settings['title_tag'] );
 				$output   .= '<' . esc_html( $title_tag ) . ' ' . $this->get_render_attribute_string( 'title' ) . '>';
 
 				// Title string.
@@ -1050,7 +1050,7 @@ class Pricing_Table extends Widget_Base {
 			}
 			if ( ! empty( $settings['subtitle'] ) ) {
 				// Start of subtitle tag.
-				$subtitle_tag = in_array( $settings['subtitle_tag'], array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ), true ) ? $settings['subtitle_tag'] : 'h1';
+				$subtitle_tag = $this->sanitize_tag( $settings['subtitle_tag'] );
 				$output      .= '<' . esc_html( $subtitle_tag ) . ' ' . $this->get_render_attribute_string( 'subtitle' ) . '>';
 
 				// Subtitle string.
@@ -1158,6 +1158,17 @@ class Pricing_Table extends Widget_Base {
 			$output .= '</span>';
 		}
 		return $output;
+	}
+
+	/**
+	 * Sanitize html tags.
+	 *
+	 * @param string $tag HTML tagname.
+	 *
+	 * @return string
+	 */
+	private function sanitize_tag( $tag ) {
+		return in_array( $tag, array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ), true ) ? $tag : 'h1';
 	}
 }
 


### PR DESCRIPTION
### Summary
Fixed vulnerability issue with `title_tag` and `subtitle_tag` tags.

### Will affect visual aspect of the product
Yes

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/hestia-pro/issues/2778
