### PR TITLE
Fixed escape html tag in posts grid widget

### DIFF
--- a/obfx_modules/elementor-extra-widgets/widgets/elementor/posts-grid.php
+++ b/obfx_modules/elementor-extra-widgets/widgets/elementor/posts-grid.php
@@ -1638,8 +1638,9 @@ class Posts_Grid extends Widget_Base {
 		$settings = $this->get_settings();
 
 		if ( $settings['grid_title_hide'] !== 'yes' ) {
+			$tag = in_array( $settings['grid_title_tag'], array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ), true ) ? $settings['grid_title_tag'] : 'h1';
 			?>
-			<<?php echo $settings['grid_title_tag']; ?> class="entry-title obfx-grid-title">
+			<<?php echo $tag; ?> class="entry-title obfx-grid-title">
 			<?php if ( $settings['grid_title_link'] == 'yes' ) { ?>
 				<a href="<?php the_permalink(); ?>" title="<?php the_title(); ?>">
 					<?php the_title(); ?>
@@ -1649,7 +1650,7 @@ class Posts_Grid extends Widget_Base {
 				the_title();
 			}
 			?>
-			</<?php echo $settings['grid_title_tag']; ?>>
+			</<?php echo $tag; ?>>
 			<?php
 		}
 	}


### PR DESCRIPTION
### Summary
Fixed vulnerability issue with `grid_title_tag` tags.

### Will affect visual aspect of the product
Yes

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/hestia-pro/issues/2779
