### PR TITLE
fix: compatibility issue with elementor v3.28.0

### DIFF
--- a/.github/workflows/build-dev-artifacts.yml
+++ b/.github/workflows/build-dev-artifacts.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Configure Composer cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Setup Composer cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -60,7 +60,7 @@ jobs:
           run: |
             echo "::set-output name=dir::$(composer config cache-files-dir)"
         - name: Setup Composer cache
-          uses: actions/cache@v1
+          uses: actions/cache@v4
           with:
             path: ${{ steps.composer-cache.outputs.dir }}
             key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/obfx_modules/content-forms/includes/widgets-admin/elementor/elementor_widget_manager.php
+++ b/obfx_modules/content-forms/includes/widgets-admin/elementor/elementor_widget_manager.php
@@ -109,7 +109,7 @@ class Elementor_Widget_Manager {
 	 */
 	public function before_settings_save( $data, $document ) {
 		if ( ! isset( $data['elements'] ) ) {
-			return;
+			return $data;
 		}
 		$this->search_and_modify_widget_settings( $data['elements'] );
 		return $data;


### PR DESCRIPTION
### Summary
I've fixed the PHP fatal errors when edit the page using elementor v3.28.0

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/themeisle-companion/issues/896
