### PR TITLE
Fix: template directory redirect

### DIFF
--- a/obfx_modules/template-directory/init.php
+++ b/obfx_modules/template-directory/init.php
@@ -203,7 +203,7 @@ class Template_Directory_OBFX_Module extends Orbit_Fox_Module_Abstract {
 					'cta'      => $this->get_state( 'tpc' ),
 					'activate' => $this->get_tcp_activation_link(),
 				),
-				'tpcAdminURL' => admin_url( 'admin.php?page=tiob-starter-sites' ),
+				'tpcAdminURL' => admin_url( 'admin.php?page=neve-onboarding' ),
 				'nonce'       => wp_create_nonce( 'wp_rest' ),
 				'strings'     => array(
 					'themeNotInstalled' => __( 'In order to import any starter sites, Neve theme & Templates Cloud plugin need to be installed and activated. Click the button below to install and activate Neve.', 'themeisle-companion' ),


### PR DESCRIPTION
### Summary
Fixes the template directory redirect url which was changed during a PRF for Neve.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Installing and activating via the template directory OrbitFox page should work;
- Navigating to the template directory OrbitFox page after the plugin is activated should work fine;

## Check before Pull Request is ready:

* ~[ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR~
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* ~[ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)~

<!-- Issues that this pull request closes. -->
Closes #911.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
