### PR TITLE
Fix: Builder widgets module duplicated

### DIFF
--- a/core/app/class-orbit-fox-global-settings.php
+++ b/core/app/class-orbit-fox-global-settings.php
@@ -64,14 +64,14 @@ class Orbit_Fox_Global_Settings {
 					'social-sharing',
 					'google-analytics',
 					'companion-legacy',
-					'elementor-widgets',
 					'template-directory',
 					'menu-icons',
 					'mystock-import',
 					'policy-notice',
-					'beaver-widgets',
 					'header-footer-scripts',
+					'elementor-widgets',
 					'custom-fonts',
+					'beaver-widgets',
 				)
 			);
 		}// End if().

--- a/obfx_modules/beaver-widgets/init.php
+++ b/obfx_modules/beaver-widgets/init.php
@@ -34,8 +34,8 @@ class Beaver_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 * @access  public
 	 */
 	public function set_module_strings() {
-		$this->name        = __( 'Page builder widgets', 'themeisle-companion' );
-		$this->description = __( 'Adds widgets to the most popular builders: Elementor or Beaver. More to come!', 'themeisle-companion' );
+		$this->name        = __('Beaver Builder widgets', 'themeisle-companion');
+		$this->description = __('Adds widgets to the Beaver Builder.', 'themeisle-companion');
 	}
 
 	/**

--- a/obfx_modules/content-forms/form_manager.php
+++ b/obfx_modules/content-forms/form_manager.php
@@ -113,13 +113,15 @@ class Form_Manager {
 	 * Load Elementor, Beaver or other widgets manager class.
 	 */
 	private function make() {
-		if ( defined( 'ELEMENTOR_PATH' ) && class_exists( 'Elementor\Widget_Base' ) ) {
+		$model = new \Orbit_Fox_Model();
+
+		if (defined('ELEMENTOR_PATH') && class_exists('Elementor\Widget_Base') && $model->get_is_module_active('elementor-widgets', true)) {
 			require_once 'includes/widgets-admin/elementor/elementor_widget_manager.php';
 			$elementor_manager = new Elementor_Widget_Manager();
 			$elementor_manager->init();
 		}
 
-		if ( class_exists( '\FLBuilderModel' ) ) {
+		if (class_exists('\FLBuilderModel') && $model->get_is_module_active('beaver-widgets', true)) {
 			require_once 'includes/widgets-admin/beaver/beaver_widget_manager.php';
 			$beaver_manager = new Beaver_Widget_Manager();
 			$beaver_manager->register_beaver_module();

--- a/obfx_modules/elementor-widgets/init.php
+++ b/obfx_modules/elementor-widgets/init.php
@@ -39,8 +39,8 @@ class Elementor_Widgets_OBFX_Module extends Orbit_Fox_Module_Abstract {
 	 * @access  public
 	 */
 	public function set_module_strings() {
-		$this->name        = __( 'Page builder widgets', 'themeisle-companion' );
-		$this->description = __( 'Adds widgets to the most popular builders: Elementor or Beaver. More to come!', 'themeisle-companion' );
+		$this->name        = __('Elementor widgets', 'themeisle-companion');
+		$this->description = __('Adds widgets to the Elementor page builder.', 'themeisle-companion');
 
 		if ( self::should_add_placeholders() ) {
 			$this->description .=


### PR DESCRIPTION
### Summary
Previously, both the Beaver and Elementor module had the same title and description (we probably assumed that users might have one or the other - which should be true for most cases). Now they are renamed for each builder. 

The content forms were loaded without any check, so it didn't matter if any of the modules were on or off. They get loaded conditionally for each builder now.

<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
<img width="729" height="298" alt="image" src="https://github.com/user-attachments/assets/4d8608d7-1ad9-43a8-8312-1106478fdedc" />

### Test instructions
<!-- Describe how this pull request can be tested. -->

- 
- 

## Check before Pull Request is ready:

* [ ] ~I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR~
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* ~[ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)~

<!-- Issues that this pull request closes. -->
Closes #402.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
