### PR TITLE
Feat: post duplicator module

### DIFF
--- a/core/app/class-orbit-fox-global-settings.php
+++ b/core/app/class-orbit-fox-global-settings.php
@@ -72,6 +72,7 @@ class Orbit_Fox_Global_Settings {
 					'beaver-widgets',
 					'header-footer-scripts',
 					'custom-fonts',
+					'post-duplicator',
 				)
 			);
 		}// End if().

--- a/obfx_modules/post-duplicator/init.php
+++ b/obfx_modules/post-duplicator/init.php
@@ -1,0 +1,289 @@
+<?php
+
+/**
+ * Post Duplicator Core Orbit Fox Module.
+ *
+ * @link       https://themeisle.com
+ * @since      3.0.0
+ *
+ * @package    Post_Duplicator_OBFX_Module
+ */
+
+/**
+ * The class defines a new module to be used by Orbit Fox plugin.
+ *
+ * @package    Post_Duplicator_OBFX_Module
+ * @author     Themeisle <friends@themeisle.com>
+ * @codeCoverageIgnore
+ */
+class Post_Duplicator_OBFX_Module extends Orbit_Fox_Module_Abstract {
+
+	/**
+	 * Setup module strings
+	 *
+	 * @access  public
+	 */
+	public function set_module_strings() {
+		$this->name        = __( 'Post Duplicator', 'themeisle-companion' );
+		$this->description = __( 'Adds "Clone" option to posts and pages in the WordPress admin list. Creates new drafts copying all content and settings - a huge time-saver for managing content with complex layouts.', 'themeisle-companion' );
+	}
+
+	/**
+	 * Enable module by default
+	 *
+	 * @return bool
+	 */
+	public function enable_module() {
+		return true;
+	}
+
+	/**
+	 * Load module
+	 */
+	public function load() {
+	}
+
+	/**
+	 * Define module options
+	 *
+	 * @return array
+	 */
+	public function options() {
+		return array();
+	}
+
+	/**
+	 * Admin enqueue scripts and styles
+	 *
+	 * @return array
+	 */
+	public function admin_enqueue() {
+		return array();
+	}
+
+	/**
+	 * Public enqueue scripts and styles
+	 *
+	 * @return array
+	 */
+	public function public_enqueue() {
+		return array();
+	}
+
+	/**
+	 * Register hooks
+	 */
+	public function hooks() {
+		// Add duplicate links to post lists
+		$this->loader->add_filter( 'post_row_actions', $this, 'add_duplicate_link', 10, 2 );
+		$this->loader->add_filter( 'page_row_actions', $this, 'add_duplicate_link', 10, 2 );
+
+		// Handle duplicate action
+		$this->loader->add_action( 'admin_action_duplicate_post', $this, 'handle_duplicate_post' );
+
+		// Add duplicate links for all post types
+		$this->loader->add_action( 'admin_init', $this, 'add_all_post_type_duplicate_links' );
+	}
+
+	/**
+	 * Add duplicate link to post/page row actions
+	 *
+	 * @param array    $actions Array of row action links
+	 * @param WP_Post  $post   The post object
+	 * @return array
+	 */
+	public function add_duplicate_link( $actions, $post ) {
+		// Check if user can edit this post type
+		if ( ! current_user_can( 'edit_post', $post->ID ) ) {
+			return $actions;
+		}
+
+		$duplicate_url = wp_nonce_url(
+			admin_url( 'admin.php?action=duplicate_post&post=' . $post->ID ),
+			'duplicate_post_' . $post->ID,
+			'duplicate_nonce'
+		);
+
+		$actions['duplicate'] = sprintf(
+			'<a href="%s" class="duplicate-post-link" title="%s">%s</a>',
+			esc_url( $duplicate_url ),
+			esc_attr__( 'Create a duplicate of this post', 'themeisle-companion' ),
+			esc_html__( 'Clone', 'themeisle-companion' )
+		);
+
+		return $actions;
+	}
+
+	/**
+	 * Add duplicate links for all post types
+	 */
+	public function add_all_post_type_duplicate_links() {
+		// Get all post types (built-in and custom)
+		$post_types = get_post_types( array(), 'objects' );
+
+		foreach ( $post_types as $post_type ) {
+			// Skip attachments and other non-content post types
+			if ( in_array( $post_type->name, array( 'attachment', 'revision', 'nav_menu_item', 'custom_css', 'customize_changeset' ) ) ) {
+				continue;
+			}
+
+			// Add filter for this post type's row actions
+			$this->loader->add_filter( $post_type->name . '_row_actions', $this, 'add_duplicate_link', 10, 2 );
+		}
+	}
+
+	/**
+	 * Handle the duplicate post action
+	 */
+	public function handle_duplicate_post() {
+		if ( ! isset( $_GET['post'], $_GET['duplicate_nonce'] ) ) {
+			wp_die( esc_html__( 'Missing required parameters.', 'themeisle-companion' ) );
+		}
+
+		$nonce   = sanitize_text_field( $_GET['duplicate_nonce'] );
+		$post_id = intval( sanitize_text_field( $_GET['post'] ) );
+
+		// Verify nonce
+		if ( ! wp_verify_nonce( $nonce, 'duplicate_post_' . $post_id ) ) {
+			wp_die( esc_html__( 'Security check failed.', 'themeisle-companion' ) );
+		}
+
+		$post = get_post( $post_id );
+
+		if ( ! $post ) {
+			wp_die( esc_html__( 'Post not found.', 'themeisle-companion' ) );
+		}
+
+		if ( ! current_user_can( 'edit_post', $post->ID ) ) {
+			wp_die( esc_html__( 'You do not have permission to duplicate this post.', 'themeisle-companion' ) );
+		}
+
+		$duplicate_id = $this->duplicate_post( $post );
+
+		if ( $duplicate_id ) {
+			// Redirect to the edit page of the new post
+			$redirect_url = add_query_arg(
+				array(
+					'post'       => $duplicate_id,
+					'action'     => 'edit',
+					'duplicated' => '1',
+				),
+				admin_url( 'post.php' )
+			);
+			wp_redirect( $redirect_url );
+			exit;
+		} else {
+			wp_die( esc_html__( 'Failed to duplicate post.', 'themeisle-companion' ) );
+		}
+	}
+
+	/**
+	 * Duplicate a post
+	 *
+	 * @param WP_Post $post The post to duplicate
+	 * @return int|false The new post ID or false on failure
+	 */
+	private function duplicate_post( $post ) {
+		$slug = $post->post_name;
+		if ( ! empty( $slug ) ) {
+			$slug    = $slug . '-copy';
+			$counter = 1;
+			while ( get_page_by_path( $slug, OBJECT, $post->post_type ) ) {
+				$slug = $post->post_name . '-copy-' . $counter;
+				$counter++;
+			}
+		}
+
+		$post_data = array(
+			'post_title'     => $post->post_title . ' - ' . __( 'Copy', 'themeisle-companion' ),
+			'post_content'   => $post->post_content,
+			'post_excerpt'   => $post->post_excerpt,
+			'post_status'    => 'draft',
+			'post_type'      => $post->post_type,
+			'post_name'      => $slug,
+			'post_parent'    => $post->post_parent,
+			'menu_order'     => $post->menu_order,
+			'comment_status' => $post->comment_status,
+			'ping_status'    => $post->ping_status,
+			'post_author'    => get_current_user_id(),
+		);
+
+		$duplicate_id = wp_insert_post( $post_data );
+
+		if ( is_wp_error( $duplicate_id ) ) {
+			return false;
+		}
+
+		$this->duplicate_post_meta( $post->ID, $duplicate_id );
+		$this->duplicate_post_taxonomies( $post->ID, $duplicate_id );
+		$this->set_featured_image( $post->ID, $duplicate_id );
+
+		return $duplicate_id;
+	}
+
+	/**
+	 * Duplicate post meta fields
+	 *
+	 * @param int $original_id Original post ID
+	 * @param int $duplicate_id Duplicate post ID
+	 */
+	private function duplicate_post_meta( $original_id, $duplicate_id ) {
+		$meta_keys = get_post_custom_keys( $original_id );
+
+		if ( ! $meta_keys ) {
+			return;
+		}
+
+		// Meta keys to skip (these are usually auto-generated or should not be duplicated)
+		$skip_keys = apply_filters(
+			'obfx_post_duplicator_skip_meta_keys',
+			array(
+				'_edit_lock',
+				'_edit_last',
+				'_wp_page_template',
+			),
+			$original_id
+		);
+
+		foreach ( $meta_keys as $meta_key ) {
+			if ( in_array( $meta_key, $skip_keys ) ) {
+				continue;
+			}
+
+			$meta_values = get_post_meta( $original_id, $meta_key, false );
+
+			foreach ( $meta_values as $meta_value ) {
+				add_post_meta( $duplicate_id, $meta_key, $meta_value );
+			}
+		}
+	}
+
+	/**
+	 * Duplicate post taxonomies
+	 *
+	 * @param int $original_id Original post ID
+	 * @param int $duplicate_id Duplicate post ID
+	 */
+	private function duplicate_post_taxonomies( $original_id, $duplicate_id ) {
+		$taxonomies = get_object_taxonomies( get_post_type( $original_id ) );
+
+		foreach ( $taxonomies as $taxonomy ) {
+			$terms = wp_get_object_terms( $original_id, $taxonomy, array( 'fields' => 'slugs' ) );
+			wp_set_object_terms( $duplicate_id, $terms, $taxonomy );
+		}
+	}
+
+	/**
+	 * Duplicate featured image
+	 *
+	 * @param int $original_id Original post ID
+	 * @param int $duplicate_id Duplicate post ID
+	 */
+	private function set_featured_image( $original_id, $duplicate_id ) {
+		$thumbnail_id = get_post_thumbnail_id( $original_id );
+
+		if ( $thumbnail_id ) {
+			set_post_thumbnail( $duplicate_id, $thumbnail_id );
+		}
+	}
+}

--- a/tests/test-module-post-duplicator.php
+++ b/tests/test-module-post-duplicator.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * WordPress unit test plugin.
+ *
+ * @package     Orbit_Fox
+ * @subpackage  Orbit_Fox/tests
+ * @copyright   Copyright (c) 2017, Bogdan Preda
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since 3.0.0
+ */
+class Test_Module_Post_Duplicator extends WP_UnitTestCase {
+
+  /**
+   * @var Post_Duplicator_OBFX_Module
+   */
+  private $module;
+
+  /**
+   * @var Orbit_Fox_Loader
+   */
+  private $loader;
+
+  public function tearDown(): void {
+    parent::tearDown();
+
+    // Clean up any posts created during tests
+    $posts = get_posts(array(
+      'post_type' => 'any',
+      'numberposts' => -1,
+      'post_status' => 'any',
+    ));
+
+    foreach ($posts as $post) {
+      wp_delete_post($post->ID, true);
+    }
+    $this->reset_post_id_increment();
+  }
+
+  public function setUp(): void {
+    parent::setUp();
+
+
+    // Create a mock loader
+    $this->loader = $this->createMock('Orbit_Fox_Loader');
+
+    // Create the module instance
+    $this->module = new Post_Duplicator_OBFX_Module();
+    $this->module->register_loader($this->loader);
+  }
+
+  /**
+   * Test duplicate link is added for posts
+   */
+  public function test_add_duplicate_link_for_posts() {
+    $post = $this->factory->post->create_and_get(array(
+      'post_title' => 'Test Post',
+      'post_status' => 'publish',
+    ));
+
+    $actions = array(
+      'edit' => '<a href="edit.php">Edit</a>',
+      'trash' => '<a href="trash.php">Trash</a>',
+    );
+
+    $result = $this->module->add_duplicate_link($actions, $post);
+
+    $this->assertArrayHasKey('duplicate', $result);
+    $this->assertStringContainsString('Clone', $result['duplicate']);
+    $this->assertStringContainsString('post=' . $post->ID, $result['duplicate']);
+  }
+
+  /**
+   * Test duplicate link is added for pages
+   */
+  public function test_add_duplicate_link_for_pages() {
+    $page = $this->factory->post->create_and_get(array(
+      'post_title' => 'Test Page',
+      'post_type' => 'page',
+      'post_status' => 'publish',
+    ));
+
+    wp_set_current_user(1);
+
+    $actions = array(
+      'edit' => '<a href="edit.php">Edit</a>',
+      'trash' => '<a href="trash.php">Trash</a>',
+    );
+
+    $result = $this->module->add_duplicate_link($actions, $page);
+
+    $this->assertArrayHasKey('duplicate', $result);
+    $this->assertStringContainsString('Clone', $result['duplicate']);
+    $this->assertStringContainsString('post=' . $page->ID, $result['duplicate']);
+  }
+
+  /**
+   * Test basic post duplication functionality
+   */
+  public function test_duplicate_post_basic() {
+    $original_post = $this->factory->post->create_and_get(array(
+      'post_title' => 'Original Post',
+      'post_content' => 'Original content',
+      'post_status' => 'publish',
+    ));
+
+    $reflection = new ReflectionClass($this->module);
+    $method = $reflection->getMethod('duplicate_post');
+    $method->setAccessible(true);
+
+    $duplicate_id = $method->invoke($this->module, $original_post);
+
+    $this->assertNotFalse($duplicate_id);
+    $this->assertIsInt($duplicate_id);
+
+    $duplicate_post = get_post($duplicate_id);
+    $this->assertNotNull($duplicate_post);
+    $this->assertEquals('Original Post - Copy', $duplicate_post->post_title);
+    $this->assertEquals('draft', $duplicate_post->post_status);
+  }
+
+  private function reset_post_id_increment($start_id = 1) {
+    global $wpdb;
+    $wpdb->query("ALTER TABLE {$wpdb->posts} AUTO_INCREMENT = {$start_id}");
+  }
+}

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -17,14 +17,14 @@ class Test_Orbit_Fox extends WP_UnitTestCase {
 	protected $plugin_name;
 	protected $plugin_version;
 
-	public function tearDown() {
+	public function tearDown(): void {
 		Orbit_Fox_Global_Settings::destroy_instance();
 
 		$obfx_model = new Orbit_Fox_Model();
 		$obfx_model->destroy_model();
 	}
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->obfx = new Orbit_Fox();
 
 		$this->plugin_name = $this->obfx->get_plugin_name();
@@ -116,7 +116,7 @@ class Test_Orbit_Fox extends WP_UnitTestCase {
 		$rdh->render_option( array( 'type' => 'toggle', 'value' => '1' ) );
 		$rdh->render_option( array( 'type' => 'unknown' ) );
 
-		$this->invokeMethod( $rdh, 'sanitize_option', array( 'type' => 'text' ) );
+		$this->invokeMethod($rdh, 'sanitize_option', array(array('type' => 'text')));
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Adds the Post Duplicator module. 

<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
<img width="1445" height="828" alt="image" src="https://github.com/user-attachments/assets/b9b71ab9-e4d5-41a8-bd24-a19e9efbec19" />
<img width="1906" height="856" alt="image" src="https://github.com/user-attachments/assets/1bca7e17-6b8a-4275-849a-ce0d39bf59c1" />


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Enable the module
- In the post / pages / any other CPT list view, there should be a **Clone** button in the post row actions for each;
- When cloning, a new post should be drafted, identical to the one you cloned;

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #913.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
