### PR TITLE
Fix: scroll contact form notifications into view after submission

### DIFF
--- a/obfx_modules/content-forms/assets/content-forms.js
+++ b/obfx_modules/content-forms/assets/content-forms.js
@@ -175,7 +175,7 @@ and GPL (http://www.opensource.org/licenses/gpl-license.php) licenses.
         });
     });
 
-    /**
+    /** 
      * Handle Form notices
      * @param notice
      * @param type
@@ -188,15 +188,23 @@ and GPL (http://www.opensource.org/licenses/gpl-license.php) licenses.
             noticeStatus = 'content-form-error';
         }
         var noticeData = typeof notice.responseText !== 'undefined' ? jQuery.parseJSON(notice.responseText) :  notice;
-		var noticeText = noticeData.message;
-		var style = typeof formStyle !== 'undefined' && formStyle.formStyle !== '' ? formStyle.formStyle : '';
+        var noticeText = noticeData.message;
+        var style = typeof formStyle !== 'undefined' && formStyle.formStyle !== '' ? formStyle.formStyle : '';
 
         var noticeEl = '<div class="content-form-notice-wrapper"><h3 ' + style +' class="content-form-notice ' + noticeStatus + '" >' + noticeText + '</h3></div>';
 
+        var $noticeEl;
         if ($currentNotice.length > 0) {
-            $currentNotice.replaceWith(noticeEl)
+            $noticeEl = $(noticeEl);
+            $currentNotice.replaceWith($noticeEl);
         } else {
-            $form.prepend(noticeEl);
+            $noticeEl = $(noticeEl);
+            $form.prepend($noticeEl);
+        }
+
+        // Scroll the notice into view
+        if ($noticeEl && $noticeEl.length > 0) {
+            $noticeEl[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
     }
 })(jQuery);


### PR DESCRIPTION
### Summary
After you submit a form, the form notification should be scrolled into view.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install either beaver or elementor;
- Add a contact form from orbit fox (the contact form doesn't need any setup and should be enough to test as the JS logic is the same for all form types);
- Save the page, go to the frontend;
- Submit the contact form - after submission, the notification should be scrolled into view;

## Check before Pull Request is ready:

* ~[ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR~
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* ~[ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)~

<!-- Issues that this pull request closes. -->
Closes #470.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
