### PR TITLE
enh: enable static content caching for elementor widgets

### DIFF
--- a/obfx_modules/content-forms/includes/widgets-admin/elementor/elementor_widget_base.php
+++ b/obfx_modules/content-forms/includes/widgets-admin/elementor/elementor_widget_base.php
@@ -44,6 +44,15 @@ abstract class Elementor_Widget_Base extends Widget_Base {
 		return 'eicon-text-align-left';
 	}
 
+		/**
+	 * Is dynamic content.
+	 *
+	 * @return bool
+	 */
+	protected function is_dynamic_content(): bool {
+		return false;
+	}
+
 	/**
 	 * Retrieve the list of styles the content forms widgets depended on.
 	 *

--- a/obfx_modules/elementor-extra-widgets/widgets/elementor/posts-grid.php
+++ b/obfx_modules/elementor-extra-widgets/widgets/elementor/posts-grid.php
@@ -57,6 +57,15 @@ class Posts_Grid extends Widget_Base {
 	}
 
 	/**
+	 * Is dynamic content.
+	 *
+	 * @return bool
+	 */
+	protected function is_dynamic_content(): bool {
+		return false;
+	}
+
+	/**
 	 * Register dependent script.
 	 *
 	 * @return array

--- a/obfx_modules/elementor-extra-widgets/widgets/elementor/pricing-table.php
+++ b/obfx_modules/elementor-extra-widgets/widgets/elementor/pricing-table.php
@@ -54,6 +54,15 @@ class Pricing_Table extends Widget_Base {
 	}
 
 	/**
+	 * Is dynamic content.
+	 *
+	 * @return bool
+	 */
+	protected function is_dynamic_content(): bool {
+		return false;
+	}
+
+	/**
 	 * Retrieve the list of styles the pricing table widget depended on.
 	 *
 	 * @return array Widget scripts dependencies.

--- a/obfx_modules/elementor-extra-widgets/widgets/elementor/services.php
+++ b/obfx_modules/elementor-extra-widgets/widgets/elementor/services.php
@@ -53,6 +53,15 @@ class Services extends Widget_Base {
 	}
 
 	/**
+	 * Is dynamic content.
+	 *
+	 * @return bool
+	 */
+	protected function is_dynamic_content(): bool {
+		return false;
+	}
+
+	/**
 	 * Retrieve the list of styles the services widget depended on.
 	 *
 	 * @return array Widget scripts dependencies.


### PR DESCRIPTION
### Summary
Enables static widget caching for the Elementor widgets:
- Forms (all three of them);
- Pricing table widget;
- Services widget;
- Posts grid widget;

I can confirm that widget output static caching works because I tested locally with some dynamic conditions I added in the code by hand.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

This might be a bit hard to test. My suggestion is checking that all the widgets work as before - nothing visible has been changed.

I've applied the static caching to the output of all widgets as these don't change based on user state (logged in / out) or don't have any other dynamic content. 

A. Incoming from old version:
- Add all the available widgets on a page using Elementor;
- Switch to this version;
- They still should work fine;
- Edit the page and add another random widget - save the page;
- Frontend should still display the same;

B. Basic testing without old version:
- Add all the available widgets on a page using Elementor;
- Everything should display and work normally;

## Check before Pull Request is ready:

* ~[ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR~
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* ~[ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)~

<!-- Issues that this pull request closes. -->
Closes #862.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
