### PR TITLE
Fixed pagination on post type grid

### DIFF
--- a/obfx_modules/elementor-extra-widgets/widgets/elementor/posts-grid.php
+++ b/obfx_modules/elementor-extra-widgets/widgets/elementor/posts-grid.php
@@ -57,15 +57,6 @@ class Posts_Grid extends Widget_Base {
 	}
 
 	/**
-	 * Is dynamic content.
-	 *
-	 * @return bool
-	 */
-	protected function is_dynamic_content(): bool {
-		return false;
-	}
-
-	/**
 	 * Register dependent script.
 	 *
 	 * @return array


### PR DESCRIPTION
### Summary
Remove the `is_dynamic_content` function to ensure the content is rendered based on pagination. Since this function returns false, the content is being displayed from the cached value.

### Test instructions
- Save the page or post containing the “Post Type Grid” element, or after the cache expires, which is set under Elementor > Settings > Performance > Element Cache.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/themeisle-companion/issues/955