### PR TITLE
Fixed fatal error

### DIFF
--- a/obfx_modules/content-forms/includes/widgets-admin/elementor/elementor_widget_base.php
+++ b/obfx_modules/content-forms/includes/widgets-admin/elementor/elementor_widget_base.php
@@ -49,7 +49,7 @@ abstract class Elementor_Widget_Base extends Widget_Base {
 	 *
 	 * @return bool
 	 */
-	protected function is_dynamic_content() {
+	protected function is_dynamic_content():bool { // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.boolFound
 		return false;
 	}
 

--- a/obfx_modules/elementor-extra-widgets/widgets/elementor/pricing-table.php
+++ b/obfx_modules/elementor-extra-widgets/widgets/elementor/pricing-table.php
@@ -58,7 +58,7 @@ class Pricing_Table extends Widget_Base {
 	 *
 	 * @return bool
 	 */
-	protected function is_dynamic_content() {
+	protected function is_dynamic_content():bool { // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.boolFound
 		return false;
 	}
 

--- a/obfx_modules/elementor-extra-widgets/widgets/elementor/services.php
+++ b/obfx_modules/elementor-extra-widgets/widgets/elementor/services.php
@@ -57,7 +57,7 @@ class Services extends Widget_Base {
 	 *
 	 * @return bool
 	 */
-	protected function is_dynamic_content() {
+	protected function is_dynamic_content():bool { // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.boolFound
 		return false;
 	}
 


### PR DESCRIPTION
### Summary
Add a `phpcs:ignore` comment to suppress the error so that the `is_dynamic_content` function remains compatible with Elementor’s required method signature.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/themeisle-companion/issues/960