### PR TITLE
Fixed xss vulnerability

### DIFF
--- a/obfx_modules/menu-icons/inc/class-menu-icons-obfx-walker.php
+++ b/obfx_modules/menu-icons/inc/class-menu-icons-obfx-walker.php
@@ -22,6 +22,6 @@ class Menu_Icons_OBFX_Walker extends Walker_Nav_Menu_Edit {
 	public function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
 		parent::start_el( $output, $item, $depth, $args, $id );
 		$icon    = isset( $item->icon ) ? $item->icon : '';
-		$output .= sprintf( '<input type="hidden" name="menu-item-icon[%d]" id="menu-item-icon-%d" value="%s">', $item->ID, $item->ID, $icon );
+		$output .= sprintf( '<input type="hidden" name="menu-item-icon[%d]" id="menu-item-icon-%d" value="%s">', $item->ID, $item->ID, esc_attr( $icon ) );
 	}
 }

--- a/obfx_modules/menu-icons/init.php
+++ b/obfx_modules/menu-icons/init.php
@@ -115,7 +115,7 @@ class Menu_Icons_OBFX_Module extends Orbit_Fox_Module_Abstract {
 				$array       = explode( '-', $icon );
 				$prefix      = reset( $array );
 				$prefix      = apply_filters( 'obfx_menu_icons_icon_class', $prefix, $icon );
-				$menu->title = sprintf( '<i class="obfx-menu-icon %s %s"></i>%s', $prefix, $icon, $menu->title );
+				$menu->title = sprintf( '<i class="obfx-menu-icon %s %s"></i>%s', esc_attr( $prefix ), esc_attr( $icon ), $menu->title );
 			}
 		}
 		return $menu;


### PR DESCRIPTION
### Summary
Escaping the output to prevent the XSS vulnerability.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/themeisle/issues/1993.
