### PR TITLE
Correct file type check for SVG uploads

### DIFF
--- a/obfx_modules/svg-uploads/init.php
+++ b/obfx_modules/svg-uploads/init.php
@@ -107,7 +107,7 @@ class Svg_Uploads_OBFX_Module extends Orbit_Fox_Module_Abstract {
 			return $file;
 		}
 
-		$file_info  = wp_check_filetype( basename( $file['tmp_name'] ) );
+		$file_info  = wp_check_filetype( basename( isset( $file['name'] ) ? $file['name'] : '' ) );
 		$file_type  = $file_info['type'];
 		$mime_types = array( 'image/svg+xml', 'image/svg' );
 


### PR DESCRIPTION
### Summary
Checked the file type of the uploaded file using `wp_check_filetype` and compared it with the allowed MIME types for SVG files.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/themeisle/issues/2057