### PR TITLE
Sanitized tags to prevent XSS

### DIFF
--- a/core/includes/class-orbit-fox.php
+++ b/core/includes/class-orbit-fox.php
@@ -175,6 +175,8 @@ class Orbit_Fox {
 	 */
 	private function define_hooks() {
 
+		$this->loader->add_action( 'obfx_sanitize_html_tag', $this, 'sanitize_html_tag', 10, 3 );
+
 		$plugin_admin = new Orbit_Fox_Admin( $this->get_plugin_name(), $this->get_version() );
 
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'load_modules' );
@@ -230,6 +232,19 @@ class Orbit_Fox {
 	 */
 	public function run() {
 		$this->loader->run();
+	}
+
+	/**
+	 * Sanitize html tags.
+	 *
+	 * @param string $tag HTML tag name.
+	 * @param array  $allowed Allowed HTML tags.
+	 * @param string $default Default HTML tag.
+	 *
+	 * @return string
+	 */
+	public function sanitize_html_tag( $tag, $allowed = array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ), $default = 'h2' ) {
+		return in_array( $tag, $allowed, true ) ? $tag : $default;
 	}
 
 }

--- a/obfx_modules/beaver-widgets/inc/common-functions.php
+++ b/obfx_modules/beaver-widgets/inc/common-functions.php
@@ -14,7 +14,7 @@ require_once $module_directory . '/custom-fields/number-field/number_field.php';
 /**
  * Sanitize html tags.
  *
- * @param string $tag HTML tagname.
+ * @param string $tag HTML tag name.
  *
  * @return string
  */

--- a/obfx_modules/beaver-widgets/inc/common-functions.php
+++ b/obfx_modules/beaver-widgets/inc/common-functions.php
@@ -12,17 +12,6 @@ $module_directory = $this->get_dir();
 require_once $module_directory . '/custom-fields/number-field/number_field.php';
 
 /**
- * Sanitize html tags.
- *
- * @param string $tag HTML tag name.
- *
- * @return string
- */
-function themeisle_sanitize_tag( $tag ) {
-	return in_array( $tag, array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ), true ) ? $tag : 'h1';
-}
-
-/**
  * Function to return padding controls.
  *
  * @param array $settings Fields settings.

--- a/obfx_modules/beaver-widgets/inc/common-functions.php
+++ b/obfx_modules/beaver-widgets/inc/common-functions.php
@@ -12,6 +12,17 @@ $module_directory = $this->get_dir();
 require_once $module_directory . '/custom-fields/number-field/number_field.php';
 
 /**
+ * Sanitize html tags.
+ *
+ * @param string $tag HTML tagname.
+ *
+ * @return string
+ */
+function themeisle_sanitize_tag( $tag ) {
+	return in_array( $tag, array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ), true ) ? $tag : 'h1';
+}
+
+/**
  * Function to return padding controls.
  *
  * @param array $settings Fields settings.

--- a/obfx_modules/beaver-widgets/modules/post-grid/includes/frontend.php
+++ b/obfx_modules/beaver-widgets/modules/post-grid/includes/frontend.php
@@ -60,7 +60,7 @@ if ( ! function_exists( 'obfx_show_post_grid_title' ) ) {
 		if ( ! empty( $settings->show_title_link ) && $settings->show_title_link === 'yes' ) {
 			echo '<a href="' . esc_url( get_permalink() ) . '">';
 		}
-		$tag = ! empty( $settings->title_tag ) ? $settings->title_tag : 'h4';
+		$tag = ! empty( $settings->title_tag ) ? apply_filters( 'obfx_sanitize_html_tag', $settings->title_tag, array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'span', 'div' ), 'h5' ) : 'h5';
 		the_title( '<' . $tag . ' class="obfx-post-grid-title">', '</' . $tag . '>' );
 		if ( ! empty( $settings->show_title_link ) && $settings->show_title_link === 'yes' ) {
 			echo '</a>';

--- a/obfx_modules/beaver-widgets/modules/pricing-table/includes/frontend.php
+++ b/obfx_modules/beaver-widgets/modules/pricing-table/includes/frontend.php
@@ -9,10 +9,13 @@
 
 $class_to_add = $settings->card_layout === 'yes' ? 'obfx-card' : '';
 
+$plan_title_tag    = themeisle_sanitize_tag( $settings->plan_title_tag );
+$plan_subtitle_tag = themeisle_sanitize_tag( $settings->plan_subtitle_tag );
+
 echo '<div class="obfx-pricing-plan ' . esc_attr( $class_to_add ) . '">';
 	echo '<div class="obfx-pricing-header">';
-		echo '<' . esc_attr( $settings->plan_title_tag ) . ' class="obfx-plan-title text-center">' . wp_kses_post( $settings->plan_title ) . '</' . esc_attr( $settings->plan_title_tag ) . '>';
-		echo '<' . esc_attr( $settings->plan_subtitle_tag ) . ' class="obfx-plan-subtitle text-center">' . wp_kses_post( $settings->plan_subtitle ) . '</' . esc_attr( $settings->plan_subtitle_tag ) . '>';
+		echo '<' . esc_html( $plan_title_tag ) . ' class="obfx-plan-title text-center">' . wp_kses_post( $settings->plan_title ) . '</' . esc_html( $plan_title_tag ) . '>';
+		echo '<' . esc_html( $plan_subtitle_tag ) . ' class="obfx-plan-subtitle text-center">' . wp_kses_post( $settings->plan_subtitle ) . '</' . esc_html( $plan_subtitle_tag ) . '>';
 	echo '</div>';
 	echo '<div class="obfx-pricing-price text-center">';
 switch ( $settings->currency_position ) {

--- a/obfx_modules/beaver-widgets/modules/pricing-table/includes/frontend.php
+++ b/obfx_modules/beaver-widgets/modules/pricing-table/includes/frontend.php
@@ -9,8 +9,8 @@
 
 $class_to_add = $settings->card_layout === 'yes' ? 'obfx-card' : '';
 
-$plan_title_tag    = themeisle_sanitize_tag( $settings->plan_title_tag );
-$plan_subtitle_tag = themeisle_sanitize_tag( $settings->plan_subtitle_tag );
+$plan_title_tag    = ! empty( $settings->plan_title_tag ) ? apply_filters( 'obfx_sanitize_html_tag', $settings->plan_title_tag ) : 'h2';
+$plan_subtitle_tag = ! empty( $settings->plan_subtitle_tag ) ? apply_filters( 'obfx_sanitize_html_tag', $settings->plan_subtitle_tag, array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ), 'p' ) : 'p';
 
 echo '<div class="obfx-pricing-plan ' . esc_attr( $class_to_add ) . '">';
 	echo '<div class="obfx-pricing-header">';

--- a/obfx_modules/elementor-extra-widgets/widgets/elementor/pricing-table.php
+++ b/obfx_modules/elementor-extra-widgets/widgets/elementor/pricing-table.php
@@ -1168,16 +1168,5 @@ class Pricing_Table extends Widget_Base {
 		}
 		return $output;
 	}
-
-	/**
-	 * Sanitize html tags.
-	 *
-	 * @param string $tag HTML tagname.
-	 *
-	 * @return string
-	 */
-	private function sanitize_tag( $tag ) {
-		return in_array( $tag, array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ), true ) ? $tag : 'h1';
-	}
 }
 

--- a/obfx_modules/elementor-extra-widgets/widgets/elementor/pricing-table.php
+++ b/obfx_modules/elementor-extra-widgets/widgets/elementor/pricing-table.php
@@ -1048,7 +1048,7 @@ class Pricing_Table extends Widget_Base {
 			$output .= '<div class="obfx-title-wrapper">';
 			if ( ! empty( $settings['title'] ) ) {
 				// Start of title tag.
-				$title_tag = $this->sanitize_tag( $settings['title_tag'] );
+				$title_tag = apply_filters( 'obfx_sanitize_html_tag', $settings['title_tag'], array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ), 'h3' );
 				$output   .= '<' . esc_html( $title_tag ) . ' ' . $this->get_render_attribute_string( 'title' ) . '>';
 
 				// Title string.
@@ -1059,7 +1059,7 @@ class Pricing_Table extends Widget_Base {
 			}
 			if ( ! empty( $settings['subtitle'] ) ) {
 				// Start of subtitle tag.
-				$subtitle_tag = $this->sanitize_tag( $settings['subtitle_tag'] );
+				$subtitle_tag = apply_filters( 'obfx_sanitize_html_tag', $settings['subtitle_tag'], array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ), 'p' );
 				$output      .= '<' . esc_html( $subtitle_tag ) . ' ' . $this->get_render_attribute_string( 'subtitle' ) . '>';
 
 				// Subtitle string.

--- a/tests/test-module-beaver-widgets.php
+++ b/tests/test-module-beaver-widgets.php
@@ -18,19 +18,6 @@ class Test_Module_Beaver_Widgets extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		// The common functions file resolves its own path through the module instance,
-		// so it has to be loaded with the module as $this. Beaver Builder is not needed
-		// for the helpers themselves.
-		$module      = new Beaver_Widgets_OBFX_Module();
-		$load_common = Closure::bind(
-			function () {
-				require_once $this->get_dir() . '/inc/common-functions.php';
-			},
-			$module,
-			'Beaver_Widgets_OBFX_Module'
-		);
-		$load_common();
-
 		$this->pricing_table_template = dirname( dirname( __FILE__ ) ) . '/obfx_modules/beaver-widgets/modules/pricing-table/includes/frontend.php';
 	}
 
@@ -69,20 +56,20 @@ class Test_Module_Beaver_Widgets extends WP_UnitTestCase {
 	/**
 	 * Supported tags should be returned unchanged.
 	 *
-	 * @covers ::themeisle_sanitize_tag
+	 * @covers Orbit_Fox::sanitize_html_tag
 	 */
-	public function test_sanitize_tag_keeps_supported_tags() {
+	public function test_sanitize_html_tag_keeps_supported_tags() {
 		foreach ( array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ) as $tag ) {
-			$this->assertEquals( $tag, themeisle_sanitize_tag( $tag ) );
+			$this->assertEquals( $tag, apply_filters( 'obfx_sanitize_html_tag', $tag ) );
 		}
 	}
 
 	/**
 	 * Anything that is not a supported tag should fall back to a safe default.
 	 *
-	 * @covers ::themeisle_sanitize_tag
+	 * @covers Orbit_Fox::sanitize_html_tag
 	 */
-	public function test_sanitize_tag_falls_back_for_unsupported_tags() {
+	public function test_sanitize_html_tag_falls_back_for_unsupported_tags() {
 		$unsupported = array(
 			'h1 onmouseover=alert(document.cookie)',
 			'p onclick=alert(1)',
@@ -94,8 +81,21 @@ class Test_Module_Beaver_Widgets extends WP_UnitTestCase {
 		);
 
 		foreach ( $unsupported as $tag ) {
-			$this->assertEquals( 'h1', themeisle_sanitize_tag( $tag ), 'Unsupported tag: ' . $tag );
+			$this->assertEquals( 'h2', apply_filters( 'obfx_sanitize_html_tag', $tag ), 'Unsupported tag: ' . $tag );
 		}
+	}
+
+	/**
+	 * Callers can narrow the allowed tags and pick their own fallback.
+	 *
+	 * @covers Orbit_Fox::sanitize_html_tag
+	 */
+	public function test_sanitize_html_tag_honours_custom_allowed_list_and_default() {
+		$allowed = array( 'h3', 'h4' );
+
+		$this->assertEquals( 'h3', apply_filters( 'obfx_sanitize_html_tag', 'h3', $allowed, 'p' ) );
+		$this->assertEquals( 'p', apply_filters( 'obfx_sanitize_html_tag', 'h1', $allowed, 'p' ) );
+		$this->assertEquals( 'p', apply_filters( 'obfx_sanitize_html_tag', 'script', $allowed, 'p' ) );
 	}
 
 	/**
@@ -114,19 +114,19 @@ class Test_Module_Beaver_Widgets extends WP_UnitTestCase {
 	}
 
 	/**
- 	 * The pricing table should reject unsafe heading tags.
+	 * The pricing table should reject unsafe heading tags and fall back to its defaults.
 	 */
 	public function test_pricing_table_sanitizes_unsupported_tags() {
 		$output = $this->render_pricing_table(
 			array(
 				'plan_title_tag'    => 'h3 onmouseover=alert(1)',
- 				'plan_subtitle_tag' => 'script',
+				'plan_subtitle_tag' => 'script',
 			)
 		);
 
-		$this->assertStringContainsString( '<h1 class="obfx-plan-title text-center">Plan title</h1>', $output );
- 		$this->assertStringContainsString( '<h1 class="obfx-plan-subtitle text-center">Plan subtitle</h1>', $output );
- 		$this->assertStringNotContainsString( 'onmouseover', $output );
- 		$this->assertStringNotContainsString( '<script', $output );
+		$this->assertStringContainsString( '<h2 class="obfx-plan-title text-center">Plan title</h2>', $output );
+		$this->assertStringContainsString( '<p class="obfx-plan-subtitle text-center">Plan subtitle</p>', $output );
+		$this->assertStringNotContainsString( 'onmouseover', $output );
+		$this->assertStringNotContainsString( '<script', $output );
 	}
 }

--- a/tests/test-module-beaver-widgets.php
+++ b/tests/test-module-beaver-widgets.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * WordPress unit test plugin.
+ *
+ * @package     Orbit_Fox
+ * @subpackage  Orbit_Fox/tests
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+class Test_Module_Beaver_Widgets extends WP_UnitTestCase {
+
+	/**
+	 * Path to the pricing table frontend template.
+	 *
+	 * @var string
+	 */
+	protected $pricing_table_template;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// The common functions file resolves its own path through the module instance,
+		// so it has to be loaded with the module as $this. Beaver Builder is not needed
+		// for the helpers themselves.
+		$module      = new Beaver_Widgets_OBFX_Module();
+		$load_common = Closure::bind(
+			function () {
+				require_once $this->get_dir() . '/inc/common-functions.php';
+			},
+			$module,
+			'Beaver_Widgets_OBFX_Module'
+		);
+		$load_common();
+
+		$this->pricing_table_template = dirname( dirname( __FILE__ ) ) . '/obfx_modules/beaver-widgets/modules/pricing-table/includes/frontend.php';
+	}
+
+	/**
+	 * Render the pricing table frontend template.
+	 *
+	 * @param array $args Settings to overwrite the defaults with.
+	 *
+	 * @return string
+	 */
+	protected function render_pricing_table( $args = array() ) {
+		$settings = (object) array_merge(
+			array(
+				'card_layout'       => 'yes',
+				'plan_title'        => 'Plan title',
+				'plan_title_tag'    => 'h2',
+				'plan_subtitle'     => 'Plan subtitle',
+				'plan_subtitle_tag' => 'p',
+				'price'             => '50',
+				'currency'          => '$',
+				'currency_position' => 'after',
+				'period'            => '/mo',
+				'features'          => array(),
+				'text'              => 'Buy now',
+				'link'              => 'https://example.com',
+			),
+			$args
+		);
+
+		ob_start();
+		include $this->pricing_table_template;
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Supported tags should be returned unchanged.
+	 *
+	 * @covers ::themeisle_sanitize_tag
+	 */
+	public function test_sanitize_tag_keeps_supported_tags() {
+		foreach ( array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p' ) as $tag ) {
+			$this->assertEquals( $tag, themeisle_sanitize_tag( $tag ) );
+		}
+	}
+
+	/**
+	 * Anything that is not a supported tag should fall back to a safe default.
+	 *
+	 * @covers ::themeisle_sanitize_tag
+	 */
+	public function test_sanitize_tag_falls_back_for_unsupported_tags() {
+		$unsupported = array(
+			'h1 onmouseover=alert(document.cookie)',
+			'p onclick=alert(1)',
+			'h2 class="evil"',
+			'script',
+			'div',
+			'H1',
+			'',
+		);
+
+		foreach ( $unsupported as $tag ) {
+			$this->assertEquals( 'h1', themeisle_sanitize_tag( $tag ), 'Unsupported tag: ' . $tag );
+		}
+	}
+
+	/**
+	 * The pricing table should render the configured heading tags.
+	 */
+	public function test_pricing_table_renders_configured_tags() {
+		$output = $this->render_pricing_table(
+			array(
+				'plan_title_tag'    => 'h3',
+				'plan_subtitle_tag' => 'h4',
+			)
+		);
+
+		$this->assertStringContainsString( '<h3 class="obfx-plan-title text-center">Plan title</h3>', $output );
+		$this->assertStringContainsString( '<h4 class="obfx-plan-subtitle text-center">Plan subtitle</h4>', $output );
+	}
+}

--- a/tests/test-module-beaver-widgets.php
+++ b/tests/test-module-beaver-widgets.php
@@ -112,4 +112,21 @@ class Test_Module_Beaver_Widgets extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<h3 class="obfx-plan-title text-center">Plan title</h3>', $output );
 		$this->assertStringContainsString( '<h4 class="obfx-plan-subtitle text-center">Plan subtitle</h4>', $output );
 	}
+
+	/**
+ 	 * The pricing table should reject unsafe heading tags.
+	 */
+	public function test_pricing_table_sanitizes_unsupported_tags() {
+		$output = $this->render_pricing_table(
+			array(
+				'plan_title_tag'    => 'h3 onmouseover=alert(1)',
+ 				'plan_subtitle_tag' => 'script',
+			)
+		);
+
+		$this->assertStringContainsString( '<h1 class="obfx-plan-title text-center">Plan title</h1>', $output );
+ 		$this->assertStringContainsString( '<h1 class="obfx-plan-subtitle text-center">Plan subtitle</h1>', $output );
+ 		$this->assertStringNotContainsString( 'onmouseover', $output );
+ 		$this->assertStringNotContainsString( '<script', $output );
+	}
 }

--- a/tests/test-module-post-duplicator.php
+++ b/tests/test-module-post-duplicator.php
@@ -40,6 +40,9 @@ class Test_Module_Post_Duplicator extends WP_UnitTestCase {
   public function setUp(): void {
     parent::setUp();
 
+    // WP_UnitTestCase resets the current user on tear down, so the capability
+    // checks need an administrator again for every test.
+    wp_set_current_user( 1 );
 
     // Create a mock loader
     $this->loader = $this->createMock('Orbit_Fox_Loader');


### PR DESCRIPTION
### Summary
Sanitize the Beaver Builder pricing table's title and subtitle to prevent XSS.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/themeisle/issues/2058